### PR TITLE
Serialization and Deserialization for parser Expression

### DIFF
--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -169,6 +169,12 @@ impl TryFrom<&str> for Program {
     }
 }
 
+impl From<Expression> for Program {
+    fn from(expression: Expression) -> Self {
+        Program { expression }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::context::Context;

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -8,9 +8,14 @@ edition = "2021"
 license = "MIT"
 categories = ["parsing"]
 
+[features]
+default = []
+serde = ["dep:serde"]
+
 [dependencies]
 lalrpop-util = { version = "0.22.0", features = ["lexer"] }
 regex = "1.4.2"
+serde = { version = "1.0.215", features = ["derive", "rc"], optional = true }
 thiserror = "1.0.40"
 
 [dev-dependencies]

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1,6 +1,10 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum RelationOp {
     LessThan,
@@ -12,6 +16,7 @@ pub enum RelationOp {
     In,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum ArithmeticOp {
     Add,
@@ -21,6 +26,7 @@ pub enum ArithmeticOp {
     Modulus,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum UnaryOp {
     Not,
@@ -29,6 +35,7 @@ pub enum UnaryOp {
     DoubleMinus,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
     Arithmetic(Box<Expression>, ArithmeticOp, Box<Expression>),
@@ -49,6 +56,7 @@ pub enum Expression {
     Ident(Arc<String>),
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Member {
     Attribute(Arc<String>),
@@ -56,6 +64,7 @@ pub enum Member {
     Fields(Vec<(Arc<String>, Expression)>),
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Atom {
     Int(i64),


### PR DESCRIPTION
I'd like to be able to store a successfully parsed CEL expression by de-/serializing it externally. To be able to use it again, I added the `Program::from(Expression)`.

I tried to check whether there are any issues with serde on the Arc-ed types but didn't find _why_ LALRPOP does the wraps. I assume it's a combination of simplifying lifetimes and that it's needed for (potentially) larger ASTs to avoid copying. In the case of most uses of CEL I would expect serialization to be the overhead either way. Maybe it's possible to put a disclaimer in some good place noting that serializing and deserializing potentially could use up much more memory than before the serialization? Either way, it shouldn't have any semantic impact, right?