### PR TITLE
Proto types

### DIFF
--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["compilers"]
 cel-parser = { path = "../parser", version = "0.8.0" }
 
 nom = "7.1.3"
-
 chrono = { version = "0.4", default-features = false, features = ["alloc", "serde"], optional = true }
 regex = { version = "1.10.5", optional = true }
 serde = "1.0"
@@ -21,6 +20,14 @@ base64 = { version = "0.22.1", optional = true }
 
 thiserror = "1.0"
 paste = "1.0"
+prost = { version = "0.13", optional = true }
+prost-types = { version = "0.13.2", optional = true }
+prost-wkt = { version = "0.6", optional = true }
+prost-wkt-types = { version = "0.6", optional = true }
+
+[build-dependencies]
+prost-build = { version = "0.13", optional = true }
+prost-wkt-build = { version = "0.6", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -35,3 +42,4 @@ default = ["regex", "chrono"]
 json = ["dep:serde_json", "dep:base64"]
 regex = ["dep:regex"]
 chrono = ["dep:chrono"]
+proto = ["dep:prost", "dep:prost-types", "dep:prost-build", "dep:prost-wkt", "dep:prost-wkt-build", "dep:prost-wkt-types", "serde/derive"]

--- a/interpreter/build.rs
+++ b/interpreter/build.rs
@@ -1,0 +1,35 @@
+fn main() {
+    #[cfg(feature = "proto")]
+    {
+        use std::{env, path::PathBuf};
+
+        use prost_wkt_build::*;
+
+        let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let descriptor_file = out.join("descriptors.bin");
+
+        let mut prost_build = prost_build::Config::new();
+        prost_build
+            .type_attribute(".", "#[derive(serde::Serialize,serde::Deserialize)]")
+            .extern_path(".google.protobuf.Any", "::prost_wkt_types::Any")
+            .extern_path(".google.protobuf.Duration", "::prost_wkt_types::Duration")
+            .extern_path(".google.protobuf.Timestamp", "::prost_wkt_types::Timestamp")
+            .extern_path(".google.protobuf.Value", "::prost_wkt_types::Value")
+            .file_descriptor_set_path(&descriptor_file)
+            .compile_protos(
+                &[
+                    "../proto/cel/expr/syntax.proto",
+                    "../proto/cel/expr/checked.proto",
+                    "../proto/cel/expr/value.proto",
+                ],
+                &["../proto/"],
+            )
+            .unwrap();
+
+        let descriptor_bytes = std::fs::read(descriptor_file).unwrap();
+
+        let descriptor = FileDescriptorSet::decode(&descriptor_bytes[..]).unwrap();
+
+        prost_wkt_build::add_serde(out, descriptor);
+    }
+}

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -29,8 +29,10 @@ pub use ser::SerializationError;
 
 #[cfg(feature = "json")]
 mod json;
-#[cfg(feature = "json")]
-pub use json::ConvertToJsonError;
+#[cfg(feature = "proto")]
+pub mod proto;
+#[cfg(test)]
+mod testing;
 
 use magic::FromContext;
 

--- a/interpreter/src/proto.rs
+++ b/interpreter/src/proto.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/cel.expr.rs"));

--- a/interpreter/src/proto.rs
+++ b/interpreter/src/proto.rs
@@ -1,1 +1,360 @@
+use std::sync::Arc;
+
+use cel_parser::{ArithmeticOp, Atom, Expression, Member, RelationOp, UnaryOp};
+
+use constant::ConstantKind;
+use expr::{
+    create_struct::{entry::KeyKind, Entry},
+    Call, CreateList, CreateStruct, ExprKind, Ident, Select,
+};
+
 include!(concat!(env!("OUT_DIR"), "/cel.expr.rs"));
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("ExpressionNotSet")]
+    ExpressionNotSet,
+
+    #[error("Unimplemented: {0}")]
+    Unimplemented(String),
+}
+
+impl TryFrom<Expr> for Expression {
+    type Error = Error;
+
+    fn try_from(proto_expr: Expr) -> Result<Self, Self::Error> {
+        let kind = proto_expr.expr_kind.ok_or(Error::ExpressionNotSet)?;
+
+        match kind {
+            ExprKind::ConstExpr(c) => {
+                match c.constant_kind.ok_or(Error::ExpressionNotSet)? {
+                    ConstantKind::NullValue(_) => Ok(Expression::Atom(Atom::Null)),
+                    ConstantKind::BoolValue(b) => Ok(Expression::Atom(Atom::Bool(b))),
+                    ConstantKind::Int64Value(n) => Ok(Expression::Atom(Atom::Int(n))),
+                    ConstantKind::Uint64Value(n) => Ok(Expression::Atom(Atom::UInt(n))),
+                    ConstantKind::DoubleValue(n) => Ok(Expression::Atom(Atom::Float(n))),
+                    ConstantKind::StringValue(s) => Ok(Expression::Atom(Atom::String(Arc::new(s)))),
+                    ConstantKind::BytesValue(b) => Ok(Expression::Atom(Atom::Bytes(Arc::new(b)))),
+                    ConstantKind::DurationValue(_d) => {
+                        // Ok(Value::Duration(TimeDelta::new(d.seconds, d.nanos as u32)))
+                        Err(Error::Unimplemented("Duration constant".to_string()))
+                    }
+                    ConstantKind::TimestampValue(_t) => {
+                        // Ok(crate::objects::Value::Timestamp(
+                        //     DateTime::from_timestamp(t.seconds, t.nanos).unwrap_or_default(),
+                        // ))
+                        Err(Error::Unimplemented("Timestamp constant".to_string()))
+                    }
+                }
+            }
+            ExprKind::IdentExpr(i) => Ok(Expression::Ident(Arc::new(i.name))),
+            ExprKind::SelectExpr(s) => {
+                let operand_expr =
+                    Expression::try_from(*s.operand.ok_or(Error::ExpressionNotSet)?)?;
+
+                Ok(Expression::Member(
+                    Box::new(operand_expr),
+                    Box::new(Member::Attribute(Arc::new(s.field))),
+                ))
+            }
+            ExprKind::CallExpr(c) => {
+                let func = Box::new(Expression::Ident(Arc::new(c.function)));
+
+                let target = c
+                    .target
+                    .map(|t| Expression::try_from(*t))
+                    .transpose()?
+                    .map(Box::new);
+
+                let args = c
+                    .args
+                    .into_iter()
+                    .map(Expression::try_from)
+                    .collect::<Result<_, _>>()?;
+
+                Ok(Expression::FunctionCall(func, target, args))
+            }
+            ExprKind::ListExpr(l) => {
+                let elements = l
+                    .elements
+                    .into_iter()
+                    .map(Expression::try_from)
+                    .collect::<Result<_, _>>()?;
+
+                Ok(Expression::List(elements))
+            }
+            ExprKind::StructExpr(s) => {
+                let fields = s
+                    .entries
+                    .into_iter()
+                    .map(|entry| {
+                        let key_expr = match entry.key_kind {
+                            Some(KeyKind::MapKey(e)) => Ok(e),
+                            Some(KeyKind::FieldKey(_s)) => {
+                                Err(Error::Unimplemented("Field key in struct expr".to_string()))
+                            }
+                            None => Err(Error::ExpressionNotSet),
+                        }?;
+                        let value_expr = entry.value.ok_or(Error::ExpressionNotSet)?;
+
+                        let key = Expression::try_from(key_expr)?;
+                        let value = Expression::try_from(value_expr)?;
+
+                        Ok((key, value))
+                    })
+                    .collect::<Result<_, _>>()?;
+
+                Ok(Expression::Map(fields))
+            }
+            ExprKind::ComprehensionExpr(_c) => {
+                Err(Error::Unimplemented("Comprehension expr".to_string()))
+            }
+        }
+    }
+}
+
+// From: https://github.com/google/cel-go/blob/6202a67201234710859d7b0e4c75a85a428fd520/common/operators/operators.go#L22-L41
+// // Symbolic operators.
+//
+// Conditional   = "_?_:_"
+// LogicalAnd    = "_&&_"
+// LogicalOr     = "_||_"
+// LogicalNot    = "!_"
+// Equals        = "_==_"
+// NotEquals     = "_!=_"
+// Less          = "_<_"
+// LessEquals    = "_<=_"
+// Greater       = "_>_"
+// GreaterEquals = "_>=_"
+// Add           = "_+_"
+// Subtract      = "_-_"
+// Multiply      = "_*_"
+// Divide        = "_/_"
+// Modulo        = "_%_"
+// Negate        = "-_"
+// Index         = "_[_]"
+// OptIndex      = "_[?_]"
+// OptSelect     = "_?._"
+//
+// // Macros, must have a valid identifier.
+// Has       = "has"
+// All       = "all"
+// Exists    = "exists"
+// ExistsOne = "exists_one"
+// Map       = "map"
+// Filter    = "filter"
+//
+// // Named operators, must not have be valid identifiers.
+// NotStrictlyFalse = "@not_strictly_false"
+// In               = "@in"
+
+fn binop_call_expr<S: Into<String>>(
+    lhs: Expression,
+    op: S,
+    rhs: Expression,
+) -> Result<ExprKind, Error> {
+    Ok(ExprKind::CallExpr(Box::new(Call {
+        target: Some(Box::new(lhs.try_into()?)),
+        function: op.into(),
+        args: vec![rhs.try_into()?],
+    })))
+}
+
+impl TryFrom<Expression> for Expr {
+    type Error = Error;
+
+    fn try_from(expr: Expression) -> Result<Self, Self::Error> {
+        match expr {
+            Expression::Arithmetic(lhs, op, rhs) => {
+                let call_expr = match op {
+                    ArithmeticOp::Add => binop_call_expr(*lhs, "_+_", *rhs),
+                    ArithmeticOp::Subtract => binop_call_expr(*lhs, "_-_", *rhs),
+                    ArithmeticOp::Divide => binop_call_expr(*lhs, "_/_", *rhs),
+                    ArithmeticOp::Multiply => binop_call_expr(*lhs, "_*_", *rhs),
+                    ArithmeticOp::Modulus => binop_call_expr(*lhs, "_%_", *rhs),
+                }?;
+
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(call_expr),
+                })
+            }
+            Expression::Relation(lhs, op, rhs) => {
+                let call_expr = match op {
+                    RelationOp::LessThan => binop_call_expr(*lhs, "_<_", *rhs),
+                    RelationOp::LessThanEq => binop_call_expr(*lhs, "_<=_", *rhs),
+                    RelationOp::GreaterThan => binop_call_expr(*lhs, "_>_", *rhs),
+                    RelationOp::GreaterThanEq => binop_call_expr(*lhs, "_>=_", *rhs),
+                    RelationOp::Equals => binop_call_expr(*lhs, "_==_", *rhs),
+                    RelationOp::NotEquals => binop_call_expr(*lhs, "_!=_", *rhs),
+                    RelationOp::In => binop_call_expr(*lhs, "@in", *rhs),
+                }?;
+
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(call_expr),
+                })
+            }
+            Expression::Ternary(cond, left, right) => {
+                let target = Some(Box::new(Expr::try_from(*cond)?));
+
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(ExprKind::CallExpr(Box::new(Call {
+                        target,
+                        function: "_?_:_".to_string(),
+                        args: vec![Expr::try_from(*left)?, Expr::try_from(*right)?],
+                    }))),
+                })
+            }
+            Expression::Or(lhs, rhs) => {
+                let call_expr = binop_call_expr(*lhs, "_||_", *rhs)?;
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(call_expr),
+                })
+            }
+            Expression::And(lhs, rhs) => {
+                let call_expr = binop_call_expr(*lhs, "_&&_", *rhs)?;
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(call_expr),
+                })
+            }
+            Expression::Unary(op, e) => {
+                let func = match op {
+                    UnaryOp::Not => Some("!_"),
+                    UnaryOp::Minus => Some("-_"),
+                    UnaryOp::DoubleNot | UnaryOp::DoubleMinus => None,
+                };
+
+                match func {
+                    None => Expr::try_from(*e),
+                    Some(name) => Ok(Expr {
+                        id: 0,
+                        expr_kind: Some(ExprKind::CallExpr(Box::new(Call {
+                            target: None,
+                            function: name.to_string(),
+                            args: vec![Expr::try_from(*e)?],
+                        }))),
+                    }),
+                }
+            }
+            Expression::Member(left, right) => match *right {
+                Member::Attribute(field) => {
+                    let operand = Some(Box::new(Expr::try_from(*left)?));
+
+                    Ok(Expr {
+                        id: 0,
+                        expr_kind: Some(ExprKind::SelectExpr(Box::new(Select {
+                            operand,
+                            field: field.as_ref().clone(),
+                            test_only: false, // TODO: has(parent.field) should become `test_only: true`
+                        }))),
+                    })
+                }
+                Member::Index(index) => {
+                    let call_expr = binop_call_expr(*left, "_[_]", *index)?;
+
+                    Ok(Expr {
+                        id: 0,
+                        expr_kind: Some(call_expr),
+                    })
+                }
+                Member::Fields(_fields) => Err(Error::Unimplemented(
+                    "Member Fields to proto conversion".to_string(),
+                )),
+            },
+            Expression::FunctionCall(expr, target, args) => {
+                let target = target
+                    .map(|t| Expr::try_from(*t))
+                    .transpose()?
+                    .map(Box::new);
+
+                let ident = match *expr {
+                    Expression::Ident(ident) => Ok(ident.as_ref().clone()),
+                    other => Err(Error::Unimplemented(format!(
+                        "proto function call expects an identifier, got: {:?}",
+                        other
+                    ))),
+                }?;
+
+                let args = args
+                    .into_iter()
+                    .map(Expr::try_from)
+                    .collect::<Result<_, _>>()?;
+
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(ExprKind::CallExpr(Box::new(Call {
+                        target,
+                        function: ident,
+                        args,
+                    }))),
+                })
+            }
+            Expression::List(exprs) => {
+                let list_kind = ExprKind::ListExpr(CreateList {
+                    elements: exprs
+                        .into_iter()
+                        .map(Expr::try_from)
+                        .collect::<Result<_, _>>()?,
+                    optional_indices: Vec::new(), // TODO: If list is dynamic or can contain None/null, this should be set
+                });
+
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(list_kind),
+                })
+            }
+            Expression::Map(exprs) => {
+                let struct_kind = ExprKind::StructExpr(CreateStruct {
+                    entries: exprs
+                        .into_iter()
+                        .map(|(key, val)| {
+                            let k = Expr::try_from(key)?;
+                            let v = Expr::try_from(val)?;
+
+                            Ok(Entry {
+                                id: 0,
+                                key_kind: Some(KeyKind::MapKey(k)),
+                                value: Some(v),
+                                optional_entry: false,
+                            })
+                        })
+                        .collect::<Result<_, _>>()?,
+                    message_name: String::new(),
+                });
+
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(struct_kind),
+                })
+            }
+            Expression::Atom(atom) => {
+                let const_ = match atom {
+                    Atom::Int(n) => ConstantKind::Int64Value(n),
+                    Atom::UInt(n) => ConstantKind::Uint64Value(n),
+                    Atom::Float(n) => ConstantKind::DoubleValue(n),
+                    Atom::String(s) => ConstantKind::StringValue(s.as_ref().clone()),
+                    Atom::Bytes(b) => ConstantKind::BytesValue(b.as_ref().clone()),
+                    Atom::Bool(b) => ConstantKind::BoolValue(b),
+                    Atom::Null => ConstantKind::NullValue(0),
+                };
+
+                Ok(Expr {
+                    id: 0,
+                    expr_kind: Some(ExprKind::ConstExpr(Constant {
+                        constant_kind: Some(const_),
+                    })),
+                })
+            }
+            Expression::Ident(s) => Ok(Expr {
+                id: 0,
+                expr_kind: Some(ExprKind::IdentExpr(Ident {
+                    name: s.as_ref().clone(),
+                })),
+            }),
+        }
+    }
+}

--- a/proto/cel/expr/checked.proto
+++ b/proto/cel/expr/checked.proto
@@ -1,0 +1,344 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "cel/expr/syntax.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "DeclProto";
+option java_package = "dev.cel.expr";
+
+// Protos for representing CEL declarations and typed checked expressions.
+
+// A CEL expression which has been successfully type checked.
+message CheckedExpr {
+  // A map from expression ids to resolved references.
+  //
+  // The following entries are in this table:
+  //
+  // - An Ident or Select expression is represented here if it resolves to a
+  //   declaration. For instance, if `a.b.c` is represented by
+  //   `select(select(id(a), b), c)`, and `a.b` resolves to a declaration,
+  //   while `c` is a field selection, then the reference is attached to the
+  //   nested select expression (but not to the id or or the outer select).
+  //   In turn, if `a` resolves to a declaration and `b.c` are field selections,
+  //   the reference is attached to the ident expression.
+  // - Every Call expression has an entry here, identifying the function being
+  //   called.
+  // - Every CreateStruct expression for a message has an entry, identifying
+  //   the message.
+  map<int64, Reference> reference_map = 2;
+
+  // A map from expression ids to types.
+  //
+  // Every expression node which has a type different than DYN has a mapping
+  // here. If an expression has type DYN, it is omitted from this map to save
+  // space.
+  map<int64, Type> type_map = 3;
+
+  // The source info derived from input that generated the parsed `expr` and
+  // any optimizations made during the type-checking pass.
+  SourceInfo source_info = 5;
+
+  // The expr version indicates the major / minor version number of the `expr`
+  // representation.
+  //
+  // The most common reason for a version change will be to indicate to the CEL
+  // runtimes that transformations have been performed on the expr during static
+  // analysis. In some cases, this will save the runtime the work of applying
+  // the same or similar transformations prior to evaluation.
+  string expr_version = 6;
+
+  // The checked expression. Semantically equivalent to the parsed `expr`, but
+  // may have structural differences.
+  Expr expr = 4;
+}
+
+// Represents a CEL type.
+message Type {
+  // List type with typed elements, e.g. `list<example.proto.MyMessage>`.
+  message ListType {
+    // The element type.
+    Type elem_type = 1;
+  }
+
+  // Map type with parameterized key and value types, e.g. `map<string, int>`.
+  message MapType {
+    // The type of the key.
+    Type key_type = 1;
+
+    // The type of the value.
+    Type value_type = 2;
+  }
+
+  // Function type with result and arg types.
+  message FunctionType {
+    // Result type of the function.
+    Type result_type = 1;
+
+    // Argument types of the function.
+    repeated Type arg_types = 2;
+  }
+
+  // Application defined abstract type.
+  message AbstractType {
+    // The fully qualified name of this abstract type.
+    string name = 1;
+
+    // Parameter types for this abstract type.
+    repeated Type parameter_types = 2;
+  }
+
+  // CEL primitive types.
+  enum PrimitiveType {
+    // Unspecified type.
+    PRIMITIVE_TYPE_UNSPECIFIED = 0;
+
+    // Boolean type.
+    BOOL = 1;
+
+    // Int64 type.
+    //
+    // 32-bit integer values are widened to int64.
+    INT64 = 2;
+
+    // Uint64 type.
+    //
+    // 32-bit unsigned integer values are widened to uint64.
+    UINT64 = 3;
+
+    // Double type.
+    //
+    // 32-bit float values are widened to double values.
+    DOUBLE = 4;
+
+    // String type.
+    STRING = 5;
+
+    // Bytes type.
+    BYTES = 6;
+  }
+
+  // Well-known protobuf types treated with first-class support in CEL.
+  enum WellKnownType {
+    // Unspecified type.
+    WELL_KNOWN_TYPE_UNSPECIFIED = 0;
+
+    // Well-known protobuf.Any type.
+    //
+    // Any types are a polymorphic message type. During type-checking they are
+    // treated like `DYN` types, but at runtime they are resolved to a specific
+    // message type specified at evaluation time.
+    ANY = 1;
+
+    // Well-known protobuf.Timestamp type, internally referenced as `timestamp`.
+    TIMESTAMP = 2;
+
+    // Well-known protobuf.Duration type, internally referenced as `duration`.
+    DURATION = 3;
+  }
+
+  // The kind of type.
+  oneof type_kind {
+    // Dynamic type.
+    google.protobuf.Empty dyn = 1;
+
+    // Null value.
+    google.protobuf.NullValue null = 2;
+
+    // Primitive types: `true`, `1u`, `-2.0`, `'string'`, `b'bytes'`.
+    PrimitiveType primitive = 3;
+
+    // Wrapper of a primitive type, e.g. `google.protobuf.Int64Value`.
+    PrimitiveType wrapper = 4;
+
+    // Well-known protobuf type such as `google.protobuf.Timestamp`.
+    WellKnownType well_known = 5;
+
+    // Parameterized list with elements of `list_type`, e.g. `list<timestamp>`.
+    ListType list_type = 6;
+
+    // Parameterized map with typed keys and values.
+    MapType map_type = 7;
+
+    // Function type.
+    FunctionType function = 8;
+
+    // Protocol buffer message type.
+    //
+    // The `message_type` string specifies the qualified message type name. For
+    // example, `google.type.PhoneNumber`.
+    string message_type = 9;
+
+    // Type param type.
+    //
+    // The `type_param` string specifies the type parameter name, e.g. `list<E>`
+    // would be a `list_type` whose element type was a `type_param` type
+    // named `E`.
+    string type_param = 10;
+
+    // Type type.
+    //
+    // The `type` value specifies the target type. e.g. int is type with a
+    // target type of `Primitive.INT64`.
+    Type type = 11;
+
+    // Error type.
+    //
+    // During type-checking if an expression is an error, its type is propagated
+    // as the `ERROR` type. This permits the type-checker to discover other
+    // errors present in the expression.
+    google.protobuf.Empty error = 12;
+
+    // Abstract, application defined type.
+    //
+    // An abstract type has no accessible field names, and it can only be
+    // inspected via helper / member functions.
+    AbstractType abstract_type = 14;
+  }
+}
+
+// Represents a declaration of a named value or function.
+//
+// A declaration is part of the contract between the expression, the agent
+// evaluating that expression, and the caller requesting evaluation.
+message Decl {
+  // Identifier declaration which specifies its type and optional `Expr` value.
+  //
+  // An identifier without a value is a declaration that must be provided at
+  // evaluation time. An identifier with a value should resolve to a constant,
+  // but may be used in conjunction with other identifiers bound at evaluation
+  // time.
+  message IdentDecl {
+    // Required. The type of the identifier.
+    Type type = 1;
+
+    // The constant value of the identifier. If not specified, the identifier
+    // must be supplied at evaluation time.
+    Constant value = 2;
+
+    // Documentation string for the identifier.
+    string doc = 3;
+  }
+
+  // Function declaration specifies one or more overloads which indicate the
+  // function's parameter types and return type.
+  //
+  // Functions have no observable side-effects (there may be side-effects like
+  // logging which are not observable from CEL).
+  message FunctionDecl {
+    // An overload indicates a function's parameter types and return type, and
+    // may optionally include a function body described in terms of
+    // [Expr][cel.expr.Expr] values.
+    //
+    // Functions overloads are declared in either a function or method
+    // call-style. For methods, the `params[0]` is the expected type of the
+    // target receiver.
+    //
+    // Overloads must have non-overlapping argument types after erasure of all
+    // parameterized type variables (similar as type erasure in Java).
+    message Overload {
+      // Required. Globally unique overload name of the function which reflects
+      // the function name and argument types.
+      //
+      // This will be used by a [Reference][cel.expr.Reference] to
+      // indicate the `overload_id` that was resolved for the function `name`.
+      string overload_id = 1;
+
+      // List of function parameter [Type][cel.expr.Type] values.
+      //
+      // Param types are disjoint after generic type parameters have been
+      // replaced with the type `DYN`. Since the `DYN` type is compatible with
+      // any other type, this means that if `A` is a type parameter, the
+      // function types `int<A>` and `int<int>` are not disjoint. Likewise,
+      // `map<string, string>` is not disjoint from `map<K, V>`.
+      //
+      // When the `result_type` of a function is a generic type param, the
+      // type param name also appears as the `type` of on at least one params.
+      repeated Type params = 2;
+
+      // The type param names associated with the function declaration.
+      //
+      // For example, `function ex<K,V>(K key, map<K, V> map) : V` would yield
+      // the type params of `K, V`.
+      repeated string type_params = 3;
+
+      // Required. The result type of the function. For example, the operator
+      // `string.isEmpty()` would have `result_type` of `kind: BOOL`.
+      Type result_type = 4;
+
+      // Whether the function is to be used in a method call-style `x.f(...)`
+      // of a function call-style `f(x, ...)`.
+      //
+      // For methods, the first parameter declaration, `params[0]` is the
+      // expected type of the target receiver.
+      bool is_instance_function = 5;
+
+      // Documentation string for the overload.
+      string doc = 6;
+    }
+
+    // Required. List of function overloads, must contain at least one overload.
+    repeated Overload overloads = 1;
+  }
+
+  // The fully qualified name of the declaration.
+  //
+  // Declarations are organized in containers and this represents the full path
+  // to the declaration in its container, as in `cel.expr.Decl`.
+  //
+  // Declarations used as
+  // [FunctionDecl.Overload][cel.expr.Decl.FunctionDecl.Overload]
+  // parameters may or may not have a name depending on whether the overload is
+  // function declaration or a function definition containing a result
+  // [Expr][cel.expr.Expr].
+  string name = 1;
+
+  // Required. The declaration kind.
+  oneof decl_kind {
+    // Identifier declaration.
+    IdentDecl ident = 2;
+
+    // Function declaration.
+    FunctionDecl function = 3;
+  }
+}
+
+// Describes a resolved reference to a declaration.
+message Reference {
+  // The fully qualified name of the declaration.
+  string name = 1;
+
+  // For references to functions, this is a list of `Overload.overload_id`
+  // values which match according to typing rules.
+  //
+  // If the list has more than one element, overload resolution among the
+  // presented candidates must happen at runtime because of dynamic types. The
+  // type checker attempts to narrow down this list as much as possible.
+  //
+  // Empty if this is not a reference to a
+  // [Decl.FunctionDecl][cel.expr.Decl.FunctionDecl].
+  repeated string overload_id = 3;
+
+  // For references to constants, this may contain the value of the
+  // constant if known at compile time.
+  Constant value = 4;
+}

--- a/proto/cel/expr/syntax.proto
+++ b/proto/cel/expr/syntax.proto
@@ -1,0 +1,417 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "SyntaxProto";
+option java_package = "dev.cel.expr";
+
+// A representation of the abstract syntax of the Common Expression Language.
+
+// An expression together with source information as returned by the parser.
+message ParsedExpr {
+  // The parsed expression.
+  Expr expr = 2;
+
+  // The source info derived from input that generated the parsed `expr`.
+  SourceInfo source_info = 3;
+}
+
+// An abstract representation of a common expression.
+//
+// Expressions are abstractly represented as a collection of identifiers,
+// select statements, function calls, literals, and comprehensions. All
+// operators with the exception of the '.' operator are modelled as function
+// calls. This makes it easy to represent new operators into the existing AST.
+//
+// All references within expressions must resolve to a
+// [Decl][cel.expr.Decl] provided at type-check for an expression to be
+// valid. A reference may either be a bare identifier `name` or a qualified
+// identifier `google.api.name`. References may either refer to a value or a
+// function declaration.
+//
+// For example, the expression `google.api.name.startsWith('expr')` references
+// the declaration `google.api.name` within a
+// [Expr.Select][cel.expr.Expr.Select] expression, and the function
+// declaration `startsWith`.
+message Expr {
+  // An identifier expression. e.g. `request`.
+  message Ident {
+    // Required. Holds a single, unqualified identifier, possibly preceded by a
+    // '.'.
+    //
+    // Qualified names are represented by the
+    // [Expr.Select][cel.expr.Expr.Select] expression.
+    string name = 1;
+  }
+
+  // A field selection expression. e.g. `request.auth`.
+  message Select {
+    // Required. The target of the selection expression.
+    //
+    // For example, in the select expression `request.auth`, the `request`
+    // portion of the expression is the `operand`.
+    Expr operand = 1;
+
+    // Required. The name of the field to select.
+    //
+    // For example, in the select expression `request.auth`, the `auth` portion
+    // of the expression would be the `field`.
+    string field = 2;
+
+    // Whether the select is to be interpreted as a field presence test.
+    //
+    // This results from the macro `has(request.auth)`.
+    bool test_only = 3;
+  }
+
+  // A call expression, including calls to predefined functions and operators.
+  //
+  // For example, `value == 10`, `size(map_value)`.
+  message Call {
+    // The target of an method call-style expression. For example, `x` in
+    // `x.f()`.
+    Expr target = 1;
+
+    // Required. The name of the function or method being called.
+    string function = 2;
+
+    // The arguments.
+    repeated Expr args = 3;
+  }
+
+  // A list creation expression.
+  //
+  // Lists may either be homogenous, e.g. `[1, 2, 3]`, or heterogeneous, e.g.
+  // `dyn([1, 'hello', 2.0])`
+  message CreateList {
+    // The elements part of the list.
+    repeated Expr elements = 1;
+
+    // The indices within the elements list which are marked as optional
+    // elements.
+    //
+    // When an optional-typed value is present, the value it contains
+    // is included in the list. If the optional-typed value is absent, the list
+    // element is omitted from the CreateList result.
+    repeated int32 optional_indices = 2;
+  }
+
+  // A map or message creation expression.
+  //
+  // Maps are constructed as `{'key_name': 'value'}`. Message construction is
+  // similar, but prefixed with a type name and composed of field ids:
+  // `types.MyType{field_id: 'value'}`.
+  message CreateStruct {
+    // Represents an entry.
+    message Entry {
+      // Required. An id assigned to this node by the parser which is unique
+      // in a given expression tree. This is used to associate type
+      // information and other attributes to the node.
+      int64 id = 1;
+
+      // The `Entry` key kinds.
+      oneof key_kind {
+        // The field key for a message creator statement.
+        string field_key = 2;
+
+        // The key expression for a map creation statement.
+        Expr map_key = 3;
+      }
+
+      // Required. The value assigned to the key.
+      //
+      // If the optional_entry field is true, the expression must resolve to an
+      // optional-typed value. If the optional value is present, the key will be
+      // set; however, if the optional value is absent, the key will be unset.
+      Expr value = 4;
+
+      // Whether the key-value pair is optional.
+      bool optional_entry = 5;
+    }
+
+    // The type name of the message to be created, empty when creating map
+    // literals.
+    string message_name = 1;
+
+    // The entries in the creation expression.
+    repeated Entry entries = 2;
+  }
+
+  // A comprehension expression applied to a list or map.
+  //
+  // Comprehensions are not part of the core syntax, but enabled with macros.
+  // A macro matches a specific call signature within a parsed AST and replaces
+  // the call with an alternate AST block. Macro expansion happens at parse
+  // time.
+  //
+  // The following macros are supported within CEL:
+  //
+  // Aggregate type macros may be applied to all elements in a list or all keys
+  // in a map:
+  //
+  // *  `all`, `exists`, `exists_one` -  test a predicate expression against
+  //    the inputs and return `true` if the predicate is satisfied for all,
+  //    any, or only one value `list.all(x, x < 10)`.
+  // *  `filter` - test a predicate expression against the inputs and return
+  //    the subset of elements which satisfy the predicate:
+  //    `payments.filter(p, p > 1000)`.
+  // *  `map` - apply an expression to all elements in the input and return the
+  //    output aggregate type: `[1, 2, 3].map(i, i * i)`.
+  //
+  // The `has(m.x)` macro tests whether the property `x` is present in struct
+  // `m`. The semantics of this macro depend on the type of `m`. For proto2
+  // messages `has(m.x)` is defined as 'defined, but not set`. For proto3, the
+  // macro tests whether the property is set to its default. For map and struct
+  // types, the macro tests whether the property `x` is defined on `m`.
+  //
+  // Comprehensions for the standard environment macros evaluation can be best
+  // visualized as the following pseudocode:
+  //
+  // ```
+  // let `accu_var` = `accu_init`
+  // for (let `iter_var` in `iter_range`) {
+  //   if (!`loop_condition`) {
+  //     break
+  //   }
+  //   `accu_var` = `loop_step`
+  // }
+  // return `result`
+  // ```
+  //
+  // Comprehensions for the optional V2 macros which support map-to-map
+  // translation differ slightly from the standard environment macros in that
+  // they expose both the key or index in addition to the value for each list
+  // or map entry:
+  //
+  // ```
+  // let `accu_var` = `accu_init`
+  // for (let `iter_var`, `iter_var2` in `iter_range`) {
+  //   if (!`loop_condition`) {
+  //     break
+  //   }
+  //   `accu_var` = `loop_step`
+  // }
+  // return `result`
+  // ```
+  message Comprehension {
+    // The name of the first iteration variable.
+    // When the iter_range is a list, this variable is the list element.
+    // When the iter_range is a map, this variable is the map entry key.
+    string iter_var = 1;
+
+    // The name of the second iteration variable, empty if not set.
+    // When the iter_range is a list, this variable is the integer index.
+    // When the iter_range is a map, this variable is the map entry value.
+    // This field is only set for comprehension v2 macros.
+    string iter_var2 = 8;
+
+    // The range over which the comprehension iterates.
+    Expr iter_range = 2;
+
+    // The name of the variable used for accumulation of the result.
+    string accu_var = 3;
+
+    // The initial value of the accumulator.
+    Expr accu_init = 4;
+
+    // An expression which can contain iter_var, iter_var2, and accu_var.
+    //
+    // Returns false when the result has been computed and may be used as
+    // a hint to short-circuit the remainder of the comprehension.
+    Expr loop_condition = 5;
+
+    // An expression which can contain iter_var, iter_var2, and accu_var.
+    //
+    // Computes the next value of accu_var.
+    Expr loop_step = 6;
+
+    // An expression which can contain accu_var.
+    //
+    // Computes the result.
+    Expr result = 7;
+  }
+
+  // Required. An id assigned to this node by the parser which is unique in a
+  // given expression tree. This is used to associate type information and other
+  // attributes to a node in the parse tree.
+  int64 id = 2;
+
+  // Required. Variants of expressions.
+  oneof expr_kind {
+    // A constant expression.
+    Constant const_expr = 3;
+
+    // An identifier expression.
+    Ident ident_expr = 4;
+
+    // A field selection expression, e.g. `request.auth`.
+    Select select_expr = 5;
+
+    // A call expression, including calls to predefined functions and operators.
+    Call call_expr = 6;
+
+    // A list creation expression.
+    CreateList list_expr = 7;
+
+    // A map or message creation expression.
+    CreateStruct struct_expr = 8;
+
+    // A comprehension expression.
+    Comprehension comprehension_expr = 9;
+  }
+}
+
+// Represents a primitive literal.
+//
+// Named 'Constant' here for backwards compatibility.
+//
+// This is similar as the primitives supported in the well-known type
+// `google.protobuf.Value`, but richer so it can represent CEL's full range of
+// primitives.
+//
+// Lists and structs are not included as constants as these aggregate types may
+// contain [Expr][cel.expr.Expr] elements which require evaluation and
+// are thus not constant.
+//
+// Examples of constants include: `"hello"`, `b'bytes'`, `1u`, `4.2`, `-2`,
+// `true`, `null`.
+message Constant {
+  // Required. The valid constant kinds.
+  oneof constant_kind {
+    // null value.
+    google.protobuf.NullValue null_value = 1;
+
+    // boolean value.
+    bool bool_value = 2;
+
+    // int64 value.
+    int64 int64_value = 3;
+
+    // uint64 value.
+    uint64 uint64_value = 4;
+
+    // double value.
+    double double_value = 5;
+
+    // string value.
+    string string_value = 6;
+
+    // bytes value.
+    bytes bytes_value = 7;
+
+    // protobuf.Duration value.
+    //
+    // Deprecated: duration is no longer considered a builtin cel type.
+    google.protobuf.Duration duration_value = 8 [deprecated = true];
+
+    // protobuf.Timestamp value.
+    //
+    // Deprecated: timestamp is no longer considered a builtin cel type.
+    google.protobuf.Timestamp timestamp_value = 9 [deprecated = true];
+  }
+}
+
+// Source information collected at parse time.
+message SourceInfo {
+  // The syntax version of the source, e.g. `cel1`.
+  string syntax_version = 1;
+
+  // The location name. All position information attached to an expression is
+  // relative to this location.
+  //
+  // The location could be a file, UI element, or similar. For example,
+  // `acme/app/AnvilPolicy.cel`.
+  string location = 2;
+
+  // Monotonically increasing list of code point offsets where newlines
+  // `\n` appear.
+  //
+  // The line number of a given position is the index `i` where for a given
+  // `id` the `line_offsets[i] < id_positions[id] < line_offsets[i+1]`. The
+  // column may be derived from `id_positions[id] - line_offsets[i]`.
+  repeated int32 line_offsets = 3;
+
+  // A map from the parse node id (e.g. `Expr.id`) to the code point offset
+  // within the source.
+  map<int64, int32> positions = 4;
+
+  // A map from the parse node id where a macro replacement was made to the
+  // call `Expr` that resulted in a macro expansion.
+  //
+  // For example, `has(value.field)` is a function call that is replaced by a
+  // `test_only` field selection in the AST. Likewise, the call
+  // `list.exists(e, e > 10)` translates to a comprehension expression. The key
+  // in the map corresponds to the expression id of the expanded macro, and the
+  // value is the call `Expr` that was replaced.
+  map<int64, Expr> macro_calls = 5;
+
+  // A list of tags for extensions that were used while parsing or type checking
+  // the source expression. For example, optimizations that require special
+  // runtime support may be specified.
+  //
+  // These are used to check feature support between components in separate
+  // implementations. This can be used to either skip redundant work or
+  // report an error if the extension is unsupported.
+  repeated Extension extensions = 6;
+
+  // An extension that was requested for the source expression.
+  message Extension {
+    // Version
+    message Version {
+      // Major version changes indicate different required support level from
+      // the required components.
+      int64 major = 1;
+      // Minor version changes must not change the observed behavior from
+      // existing implementations, but may be provided informationally.
+      int64 minor = 2;
+    }
+
+    // CEL component specifier.
+    enum Component {
+      // Unspecified, default.
+      COMPONENT_UNSPECIFIED = 0;
+      // Parser. Converts a CEL string to an AST.
+      COMPONENT_PARSER = 1;
+      // Type checker. Checks that references in an AST are defined and types
+      // agree.
+      COMPONENT_TYPE_CHECKER = 2;
+      // Runtime. Evaluates a parsed and optionally checked CEL AST against a
+      // context.
+      COMPONENT_RUNTIME = 3;
+    }
+
+    // Identifier for the extension. Example: constant_folding
+    string id = 1;
+
+    // If set, the listed components must understand the extension for the
+    // expression to evaluate correctly.
+    //
+    // This field has set semantics, repeated values should be deduplicated.
+    repeated Component affected_components = 2;
+
+    // Version info. May be skipped if it isn't meaningful for the extension.
+    // (for example constant_folding might always be v0.0).
+    Version version = 3;
+  }
+}

--- a/proto/cel/expr/value.proto
+++ b/proto/cel/expr/value.proto
@@ -1,0 +1,114 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cel.expr;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
+option cc_enable_arenas = true;
+option go_package = "cel.dev/expr";
+option java_multiple_files = true;
+option java_outer_classname = "ValueProto";
+option java_package = "dev.cel.expr";
+
+// Contains representations for CEL runtime values.
+
+// Represents a CEL value.
+//
+// This is similar to `google.protobuf.Value`, but can represent CEL's full
+// range of values.
+message Value {
+  // Required. The valid kinds of values.
+  oneof kind {
+    // Null value.
+    google.protobuf.NullValue null_value = 1;
+
+    // Boolean value.
+    bool bool_value = 2;
+
+    // Signed integer value.
+    int64 int64_value = 3;
+
+    // Unsigned integer value.
+    uint64 uint64_value = 4;
+
+    // Floating point value.
+    double double_value = 5;
+
+    // UTF-8 string value.
+    string string_value = 6;
+
+    // Byte string value.
+    bytes bytes_value = 7;
+
+    // An enum value.
+    EnumValue enum_value = 9;
+
+    // The proto message backing an object value.
+    google.protobuf.Any object_value = 10;
+
+    // Map value.
+    MapValue map_value = 11;
+
+    // List value.
+    ListValue list_value = 12;
+
+    // Type value.
+    string type_value = 15;
+  }
+}
+
+// An enum value.
+message EnumValue {
+  // The fully qualified name of the enum type.
+  string type = 1;
+
+  // The value of the enum.
+  int32 value = 2;
+}
+
+// A list.
+//
+// Wrapped in a message so 'not set' and empty can be differentiated, which is
+// required for use in a 'oneof'.
+message ListValue {
+  // The ordered values in the list.
+  repeated Value values = 1;
+}
+
+// A map.
+//
+// Wrapped in a message so 'not set' and empty can be differentiated, which is
+// required for use in a 'oneof'.
+message MapValue {
+  message Entry {
+    // The key.
+    //
+    // Must be unique with in the map.
+    // Currently only boolean, int, uint, and string values can be keys.
+    Value key = 1;
+
+    // The value.
+    Value value = 2;
+  }
+
+  // The set of map entries.
+  //
+  // CEL has fewer restrictions on keys, so a protobuf map representation
+  // cannot be used.
+  repeated Entry entries = 1;
+}


### PR DESCRIPTION
Based off of #81 . I made an attempt at some initial conversion to/from proto expressions. Does the expression IDs exist somewhere or are they computable as of now? I skipped it for now. I'll try to pick it up at a later point, but please feel free to pick it up from here!

I think what "should" be implemented is actually to/from `ParsedExpr` and `CheckedExpr` but since `Expr` is the underlying type, I went for that to begin with.