### PR TITLE
Add spans to Expression (and other types too)

### DIFF
--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -81,7 +81,6 @@ impl Context<'_> {
     where
         S: Deref<Target = Spanned<String>>,
     {
-        // let name = name.as_ref();
         match self {
             Context::Child { variables, parent } => variables
                 .get(&name.deref().inner)

--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -1,7 +1,7 @@
 use crate::magic::{Function, FunctionRegistry, Handler};
 use crate::objects::{TryIntoValue, Value};
 use crate::{functions, ExecutionError};
-use cel_parser::{Expression, Spanned, SpannedExpression};
+use cel_parser::{Expression, Spanned};
 use std::collections::HashMap;
 use std::ops::Deref;
 
@@ -130,7 +130,7 @@ impl Context<'_> {
         Value::resolve(expr, self)
     }
 
-    pub fn resolve_all(&self, exprs: &[SpannedExpression]) -> Result<Value, ExecutionError> {
+    pub fn resolve_all(&self, exprs: &[Spanned<Expression>]) -> Result<Value, ExecutionError> {
         Value::resolve_all(exprs, self)
     }
 

--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -1,7 +1,7 @@
 use crate::magic::{Function, FunctionRegistry, Handler};
 use crate::objects::{TryIntoValue, Value};
 use crate::{functions, ExecutionError};
-use cel_parser::Expression;
+use cel_parser::{Expression, ExpressionInner};
 use std::collections::HashMap;
 
 /// Context is a collection of variables and functions that can be used
@@ -125,7 +125,7 @@ impl Context<'_> {
         };
     }
 
-    pub fn resolve(&self, expr: &Expression) -> Result<Value, ExecutionError> {
+    pub fn resolve(&self, expr: &ExpressionInner) -> Result<Value, ExecutionError> {
         Value::resolve(expr, self)
     }
 

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -3,7 +3,7 @@ use crate::magic::{Arguments, Identifier, This};
 use crate::objects::{Value, ValueType};
 use crate::resolvers::{Argument, Resolver};
 use crate::ExecutionError;
-use cel_parser::Expression;
+use cel_parser::{Expression, ExpressionInner};
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -301,7 +301,7 @@ pub fn map(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: Expression,
+    expr: ExpressionInner,
 ) -> Result<Value> {
     match this {
         Value::List(items) => {
@@ -344,7 +344,7 @@ pub fn filter(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: Expression,
+    expr: ExpressionInner,
 ) -> Result<Value> {
     match this {
         Value::List(items) => {
@@ -379,7 +379,7 @@ pub fn all(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: Expression,
+    expr: ExpressionInner,
 ) -> Result<bool> {
     match this {
         Value::List(items) => {
@@ -423,7 +423,7 @@ pub fn exists(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: Expression,
+    expr: ExpressionInner,
 ) -> Result<bool> {
     match this {
         Value::List(items) => {
@@ -468,7 +468,7 @@ pub fn exists_one(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: Expression,
+    expr: ExpressionInner,
 ) -> Result<bool> {
     match this {
         Value::List(items) => {

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -3,7 +3,7 @@ use crate::magic::{Arguments, Identifier, This};
 use crate::objects::{Value, ValueType};
 use crate::resolvers::{Argument, Resolver};
 use crate::ExecutionError;
-use cel_parser::{Expression, ExpressionInner};
+use cel_parser::{Expression, Spanned, SpannedExpression};
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -17,19 +17,19 @@ type Result<T> = std::result::Result<T, ExecutionError>;
 /// to variables, and the arguments to the function call.
 #[derive(Clone)]
 pub struct FunctionContext<'context> {
-    pub name: Arc<String>,
+    pub name: Arc<Spanned<String>>,
     pub this: Option<Value>,
     pub ptx: &'context Context<'context>,
-    pub args: Vec<Expression>,
+    pub args: Vec<SpannedExpression>,
     pub arg_idx: usize,
 }
 
 impl<'context> FunctionContext<'context> {
     pub fn new(
-        name: Arc<String>,
+        name: Arc<Spanned<String>>,
         this: Option<Value>,
         ptx: &'context Context<'context>,
-        args: Vec<Expression>,
+        args: Vec<SpannedExpression>,
     ) -> Self {
         Self {
             name,
@@ -301,7 +301,7 @@ pub fn map(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: ExpressionInner,
+    expr: Expression,
 ) -> Result<Value> {
     match this {
         Value::List(items) => {
@@ -344,7 +344,7 @@ pub fn filter(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: ExpressionInner,
+    expr: Expression,
 ) -> Result<Value> {
     match this {
         Value::List(items) => {
@@ -379,7 +379,7 @@ pub fn all(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: ExpressionInner,
+    expr: Expression,
 ) -> Result<bool> {
     match this {
         Value::List(items) => {
@@ -423,7 +423,7 @@ pub fn exists(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: ExpressionInner,
+    expr: Expression,
 ) -> Result<bool> {
     match this {
         Value::List(items) => {
@@ -468,7 +468,7 @@ pub fn exists_one(
     ftx: &FunctionContext,
     This(this): This<Value>,
     ident: Identifier,
-    expr: ExpressionInner,
+    expr: Expression,
 ) -> Result<bool> {
     match this {
         Value::List(items) => {

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -3,7 +3,7 @@ use crate::magic::{Arguments, Identifier, This};
 use crate::objects::{Value, ValueType};
 use crate::resolvers::{Argument, Resolver};
 use crate::ExecutionError;
-use cel_parser::{Expression, Spanned, SpannedExpression};
+use cel_parser::{Expression, Spanned};
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ pub struct FunctionContext<'context> {
     pub name: Arc<Spanned<String>>,
     pub this: Option<Value>,
     pub ptx: &'context Context<'context>,
-    pub args: Vec<SpannedExpression>,
+    pub args: Vec<Spanned<Expression>>,
     pub arg_idx: usize,
 }
 
@@ -29,7 +29,7 @@ impl<'context> FunctionContext<'context> {
         name: Arc<Spanned<String>>,
         this: Option<Value>,
         ptx: &'context Context<'context>,
-        args: Vec<SpannedExpression>,
+        args: Vec<Spanned<Expression>>,
     ) -> Self {
         Self {
             name,

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate core;
 
 use cel_parser::{parse, ExpressionReferences, Member};
-use cel_parser::{SpanExtension, Spanned};
+use cel_parser::{Expression, SpanExtension, Spanned};
 use std::convert::TryFrom;
 use std::sync::Arc;
 use thiserror::Error;
@@ -10,7 +10,6 @@ mod macros;
 
 pub mod context;
 pub use cel_parser::error::ParseError;
-pub use cel_parser::SpannedExpression;
 pub use context::Context;
 pub use functions::FunctionContext;
 pub use objects::{ResolveResult, Value};
@@ -87,7 +86,7 @@ pub enum ExecutionError {
     /// Indicates that a function call occurred without an [`Expression::Ident`]
     /// as the function identifier.
     #[error("Unsupported function call identifier type: {0:?}")]
-    UnsupportedFunctionCallIdentifierType(SpannedExpression),
+    UnsupportedFunctionCallIdentifierType(Spanned<Expression>),
     /// Indicates that a [`Member::Fields`] construction was attempted
     /// which is not yet supported.
     #[error("Unsupported fields construction: {0:?}")]
@@ -139,7 +138,7 @@ impl ExecutionError {
 
 #[derive(Debug)]
 pub struct Program {
-    expression: SpannedExpression,
+    expression: Spanned<Expression>,
 }
 
 impl Program {

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate core;
 
 use cel_parser::{parse, ExpressionReferences, Member};
+use cel_parser::{SpanExtension, Spanned};
 use std::convert::TryFrom;
 use std::sync::Arc;
 use thiserror::Error;
@@ -9,7 +10,7 @@ mod macros;
 
 pub mod context;
 pub use cel_parser::error::ParseError;
-pub use cel_parser::Expression;
+pub use cel_parser::SpannedExpression;
 pub use context::Context;
 pub use functions::FunctionContext;
 pub use objects::{ResolveResult, Value};
@@ -55,11 +56,11 @@ pub enum ExecutionError {
     /// Indicates that the script attempted to reference a key on a type that
     /// was missing the requested key.
     #[error("No such key: {0}")]
-    NoSuchKey(Arc<String>),
+    NoSuchKey(Arc<Spanned<String>>),
     /// Indicates that the script attempted to reference an undeclared variable
     /// method, or function.
     #[error("Undeclared reference to '{0}'")]
-    UndeclaredReference(Arc<String>),
+    UndeclaredReference(Arc<Spanned<String>>),
     /// Indicates that a function expected to be called as a method, or to be
     /// called with at least one parameter.
     #[error("Missing argument or target")]
@@ -86,7 +87,7 @@ pub enum ExecutionError {
     /// Indicates that a function call occurred without an [`Expression::Ident`]
     /// as the function identifier.
     #[error("Unsupported function call identifier type: {0:?}")]
-    UnsupportedFunctionCallIdentifierType(Expression),
+    UnsupportedFunctionCallIdentifierType(SpannedExpression),
     /// Indicates that a [`Member::Fields`] construction was attempted
     /// which is not yet supported.
     #[error("Unsupported fields construction: {0:?}")]
@@ -98,11 +99,11 @@ pub enum ExecutionError {
 
 impl ExecutionError {
     pub fn no_such_key(name: &str) -> Self {
-        ExecutionError::NoSuchKey(Arc::new(name.to_string()))
+        ExecutionError::NoSuchKey(Arc::new(name.to_string().unspanned()))
     }
 
     pub fn undeclared_reference(name: &str) -> Self {
-        ExecutionError::UndeclaredReference(Arc::new(name.to_string()))
+        ExecutionError::UndeclaredReference(Arc::new(name.to_string().unspanned()))
     }
 
     pub fn invalid_argument_count(expected: usize, actual: usize) -> Self {
@@ -138,7 +139,7 @@ impl ExecutionError {
 
 #[derive(Debug)]
 pub struct Program {
-    expression: Expression,
+    expression: SpannedExpression,
 }
 
 impl Program {

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -147,7 +147,7 @@ impl Program {
     }
 
     pub fn execute(&self, context: &Context) -> ResolveResult {
-        Value::resolve(&self.expression, context)
+        Value::resolve(&self.expression.inner, context)
     }
 
     /// Returns the variables and functions referenced by the CEL program

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -1,7 +1,7 @@
 use crate::macros::{impl_conversions, impl_handler};
 use crate::resolvers::{AllArguments, Argument};
 use crate::{ExecutionError, FunctionContext, ResolveResult, Value};
-use cel_parser::Expression;
+use cel_parser::ExpressionInner;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -183,7 +183,7 @@ impl<'a, 'context> FromContext<'a, 'context> for Identifier {
         Self: Sized,
     {
         match arg_expr_from_context(ctx) {
-            Expression::Ident(ident) => Ok(Identifier(ident.clone())),
+            ExpressionInner::Ident(ident) => Ok(Identifier(ident.clone())),
             expr => Err(ExecutionError::UnexpectedType {
                 got: format!("{:?}", expr),
                 want: "identifier".to_string(),
@@ -251,7 +251,7 @@ impl<'a, 'context> FromContext<'a, 'context> for Value {
     }
 }
 
-impl<'a, 'context> FromContext<'a, 'context> for Expression {
+impl<'a, 'context> FromContext<'a, 'context> for ExpressionInner {
     fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
     where
         Self: Sized,
@@ -267,10 +267,10 @@ impl<'a, 'context> FromContext<'a, 'context> for Expression {
 /// Calling this function when there are no more arguments will result in a panic. Since this
 /// function is only ever called within the context of a controlled macro that calls it once
 /// for each argument, this should never happen.
-fn arg_expr_from_context(ctx: &mut FunctionContext) -> Expression {
+fn arg_expr_from_context(ctx: &mut FunctionContext) -> ExpressionInner {
     let idx = ctx.arg_idx;
     ctx.arg_idx += 1;
-    ctx.args[idx].clone()
+    ctx.args[idx].clone().inner
 }
 
 /// Returns the next argument specified by the context's `arg_idx` field as after resolving

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -422,7 +422,7 @@ impl Value {
                 let left = Value::resolve(&left.inner, ctx)?;
                 let right = Value::resolve(&right.inner, ctx)?;
 
-                match op {
+                match op.inner {
                     ArithmeticOp::Add => left + right,
                     ArithmeticOp::Subtract => left - right,
                     ArithmeticOp::Divide => left / right,
@@ -433,7 +433,7 @@ impl Value {
             Expression::Relation(left, op, right) => {
                 let left = Value::resolve(&left.inner, ctx)?;
                 let right = Value::resolve(&right.inner, ctx)?;
-                let res = match op {
+                let res = match op.inner {
                     RelationOp::LessThan => {
                         left.partial_cmp(&right)
                             .ok_or(ExecutionError::ValuesNotComparable(left, right))?
@@ -495,7 +495,7 @@ impl Value {
             }
             Expression::Unary(op, expr) => {
                 let expr = Value::resolve(&expr.inner, ctx)?;
-                match op {
+                match op.inner {
                     UnaryOp::Not => Ok(Value::Bool(!expr.to_bool())),
                     UnaryOp::DoubleNot => Ok(Value::Bool(expr.to_bool())),
                     UnaryOp::Minus => match expr {

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -406,7 +406,7 @@ impl From<Value> for ResolveResult {
 }
 
 impl Value {
-    pub fn resolve_all(expr: &[SpannedExpression], ctx: &Context) -> ResolveResult {
+    pub fn resolve_all(expr: &[Spanned<Expression>], ctx: &Context) -> ResolveResult {
         let mut res = Vec::with_capacity(expr.len());
         for expr in expr {
             res.push(Value::resolve(&expr.inner, ctx)?);

--- a/interpreter/src/resolvers.rs
+++ b/interpreter/src/resolvers.rs
@@ -18,7 +18,7 @@ pub trait Resolver {
 
 impl Resolver for Expression {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
-        Value::resolve(self, ctx.ptx)
+        Value::resolve(&self.inner, ctx.ptx)
     }
 }
 
@@ -40,7 +40,7 @@ impl Resolver for Argument {
                 index + 1,
                 ctx.args.len(),
             ))?;
-        Value::resolve(arg, ctx.ptx)
+        Value::resolve(&arg.inner, ctx.ptx)
     }
 }
 
@@ -57,7 +57,7 @@ impl Resolver for AllArguments {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
         let mut args = Vec::with_capacity(ctx.args.len());
         for arg in ctx.args.iter() {
-            args.push(Value::resolve(arg, ctx.ptx)?);
+            args.push(Value::resolve(&arg.inner, ctx.ptx)?);
         }
         Ok(Value::List(args.into()))
     }

--- a/interpreter/src/resolvers.rs
+++ b/interpreter/src/resolvers.rs
@@ -1,5 +1,5 @@
 use crate::{ExecutionError, FunctionContext, ResolveResult, Value};
-use cel_parser::Expression;
+use cel_parser::SpannedExpression;
 
 /// Resolver knows how to resolve a [`Value`] from a [`FunctionContext`].
 /// At their core, resolvers are responsible for taking Expressions and
@@ -16,7 +16,7 @@ pub trait Resolver {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult;
 }
 
-impl Resolver for Expression {
+impl Resolver for SpannedExpression {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
         Value::resolve(&self.inner, ctx.ptx)
     }

--- a/interpreter/src/resolvers.rs
+++ b/interpreter/src/resolvers.rs
@@ -1,5 +1,5 @@
 use crate::{ExecutionError, FunctionContext, ResolveResult, Value};
-use cel_parser::SpannedExpression;
+use cel_parser::{Expression, Spanned};
 
 /// Resolver knows how to resolve a [`Value`] from a [`FunctionContext`].
 /// At their core, resolvers are responsible for taking Expressions and
@@ -16,7 +16,7 @@ pub trait Resolver {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult;
 }
 
-impl Resolver for SpannedExpression {
+impl Resolver for Spanned<Expression> {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
         Value::resolve(&self.inner, ctx.ptx)
     }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 license = "MIT"
 categories = ["parsing"]
 
+[features]
+preserve_spans = []
+
 [dependencies]
 lalrpop-util = { version = "0.22.0", features = ["lexer"] }
 regex = "1.4.2"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 categories = ["parsing"]
 
 [features]
+default = ["preserve_spans"]
 preserve_spans = []
 
 [dependencies]

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -70,8 +70,6 @@ impl<T: Display> Display for Spanned<T> {
     }
 }
 
-pub type SpannedExpression = Spanned<Expression>;
-
 pub trait SpanExtension: Sized {
     fn unspanned(self) -> Spanned<Self> {
         Spanned {
@@ -100,34 +98,34 @@ impl SpanExtension for String {}
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
     Arithmetic(
-        Box<SpannedExpression>,
+        Box<Spanned<Expression>>,
         Spanned<ArithmeticOp>,
-        Box<SpannedExpression>,
+        Box<Spanned<Expression>>,
     ),
     Relation(
-        Box<SpannedExpression>,
+        Box<Spanned<Expression>>,
         Spanned<RelationOp>,
-        Box<SpannedExpression>,
+        Box<Spanned<Expression>>,
     ),
 
     Ternary(
-        Box<SpannedExpression>,
-        Box<SpannedExpression>,
-        Box<SpannedExpression>,
+        Box<Spanned<Expression>>,
+        Box<Spanned<Expression>>,
+        Box<Spanned<Expression>>,
     ),
-    Or(Box<SpannedExpression>, Box<SpannedExpression>),
-    And(Box<SpannedExpression>, Box<SpannedExpression>),
-    Unary(Spanned<UnaryOp>, Box<SpannedExpression>),
+    Or(Box<Spanned<Expression>>, Box<Spanned<Expression>>),
+    And(Box<Spanned<Expression>>, Box<Spanned<Expression>>),
+    Unary(Spanned<UnaryOp>, Box<Spanned<Expression>>),
 
-    Member(Box<SpannedExpression>, Box<Member>),
+    Member(Box<Spanned<Expression>>, Box<Member>),
     FunctionCall(
-        Box<SpannedExpression>,
-        Option<Box<SpannedExpression>>,
-        Vec<SpannedExpression>,
+        Box<Spanned<Expression>>,
+        Option<Box<Spanned<Expression>>>,
+        Vec<Spanned<Expression>>,
     ),
 
-    List(Vec<SpannedExpression>),
-    Map(Vec<(SpannedExpression, SpannedExpression)>),
+    List(Vec<Spanned<Expression>>),
+    Map(Vec<(Spanned<Expression>, Spanned<Expression>)>),
 
     Atom(Atom),
     Ident(Arc<Spanned<String>>),
@@ -136,8 +134,8 @@ pub enum Expression {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Member {
     Attribute(Arc<Spanned<String>>),
-    Index(Box<SpannedExpression>),
-    Fields(Vec<(Arc<Spanned<String>>, SpannedExpression)>),
+    Index(Box<Spanned<Expression>>),
+    Fields(Vec<(Arc<Spanned<String>>, Spanned<Expression>)>),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -211,7 +209,7 @@ impl ExpressionReferences<'_> {
     }
 }
 
-impl SpannedExpression {
+impl Spanned<Expression> {
     /// Returns a set of all variables referenced in the expression. Variable identifiers
     /// are represented internally as [`Arc<String>`] and this function simply clones those
     /// references into a [`HashSet`].

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -38,6 +38,12 @@ pub struct Spanned<T> {
     pub span: Option<Range<usize>>,
 }
 
+impl<T> Spanned<T> {
+    pub fn new(inner: T, span: Option<Range<usize>>) -> Self {
+        Self { inner, span }
+    }
+}
+
 impl<T: PartialEq> PartialEq for Spanned<T> {
     #[cfg(feature = "preserve_spans")]
     fn eq(&self, other: &Self) -> bool {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -45,12 +45,6 @@ impl<T> Spanned<T> {
 }
 
 impl<T: PartialEq> PartialEq for Spanned<T> {
-    #[cfg(feature = "preserve_spans")]
-    fn eq(&self, other: &Self) -> bool {
-        (self.span.is_none() || other.span.is_none() || self.span == other.span)
-            && self.inner == other.inner
-    }
-    #[cfg(not(feature = "preserve_spans"))]
     fn eq(&self, other: &Self) -> bool {
         self.inner == other.inner
     }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -34,13 +34,19 @@ pub enum UnaryOp {
 #[derive(Debug, Clone)]
 pub struct Spanned<T> {
     pub inner: T,
+    #[cfg(feature = "preserve_spans")]
     pub span: Option<Range<usize>>,
 }
 
 impl<T: PartialEq> PartialEq for Spanned<T> {
+    #[cfg(feature = "preserve_spans")]
     fn eq(&self, other: &Self) -> bool {
         (self.span.is_none() || other.span.is_none() || self.span == other.span)
             && self.inner == other.inner
+    }
+    #[cfg(not(feature = "preserve_spans"))]
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
     }
 }
 
@@ -70,13 +76,16 @@ pub trait SpanExtension: Sized {
     fn unspanned(self) -> Spanned<Self> {
         Spanned {
             inner: self,
+            #[cfg(feature = "preserve_spans")]
             span: None,
         }
     }
 
+    #[allow(unused)]
     fn spanned(self, span: Range<usize>) -> Spanned<Self> {
         Spanned {
             inner: self,
+            #[cfg(feature = "preserve_spans")]
             span: Some(span),
         }
     }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -92,7 +92,6 @@ pub trait SpanExtension: Sized {
 }
 
 impl SpanExtension for Expression {}
-impl SpanExtension for Atom {}
 impl SpanExtension for ArithmeticOp {}
 impl SpanExtension for UnaryOp {}
 impl SpanExtension for RelationOp {}
@@ -100,8 +99,16 @@ impl SpanExtension for String {}
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
-    Arithmetic(Box<SpannedExpression>, ArithmeticOp, Box<SpannedExpression>),
-    Relation(Box<SpannedExpression>, RelationOp, Box<SpannedExpression>),
+    Arithmetic(
+        Box<SpannedExpression>,
+        Spanned<ArithmeticOp>,
+        Box<SpannedExpression>,
+    ),
+    Relation(
+        Box<SpannedExpression>,
+        Spanned<RelationOp>,
+        Box<SpannedExpression>,
+    ),
 
     Ternary(
         Box<SpannedExpression>,
@@ -110,7 +117,7 @@ pub enum Expression {
     ),
     Or(Box<SpannedExpression>, Box<SpannedExpression>),
     And(Box<SpannedExpression>, Box<SpannedExpression>),
-    Unary(UnaryOp, Box<SpannedExpression>),
+    Unary(Spanned<UnaryOp>, Box<SpannedExpression>),
 
     Member(Box<SpannedExpression>, Box<Member>),
     FunctionCall(

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -71,6 +71,9 @@ impl<T: Display> Display for Spanned<T> {
 }
 
 pub trait SpanExtension: Sized {
+    /// Create a new [Spanned<T>] without any span information
+    /// e.g. for synthetic variables that do not originate from
+    /// actual source code.
     fn unspanned(self) -> Spanned<Self> {
         Spanned {
             inner: self,
@@ -80,6 +83,9 @@ pub trait SpanExtension: Sized {
     }
 
     #[allow(unused)]
+    /// Create a new [Spanned<T>] with a given span. If the
+    /// `preserve_spans` feature is turned off, the span is
+    ///  just dropped
     fn spanned(self, span: Range<usize>) -> Spanned<Self> {
         Spanned {
             inner: self,

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -1,4 +1,4 @@
-use crate::{RelationOp, ArithmeticOp, Expression, SpannedExpression, Spanned, SpanExtension, UnaryOp, Member, Atom, parse_bytes, parse_string};
+use crate::{RelationOp, ArithmeticOp, Expression, Spanned, SpanExtension, UnaryOp, Member, Atom, parse_bytes, parse_string};
 use std::sync::Arc;
 
 grammar;
@@ -75,11 +75,11 @@ pub Primary: Expression = {
     "(" <Expression> ")"
 }
 
-pub FieldInits: (Arc<Spanned<String>>, SpannedExpression) = {
+pub FieldInits: (Arc<Spanned<String>>, Spanned<Expression>) = {
     <Ident> ":" <SpannedExpression>
 }
 
-pub MapInits: (SpannedExpression, SpannedExpression) = {
+pub MapInits: (Spanned<Expression>, Spanned<Expression>) = {
     <SpannedExpression> ":" <SpannedExpression>
 }
 

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -1,4 +1,4 @@
-use crate::{RelationOp, ArithmeticOp, Expression, UnaryOp, Member, Atom, parse_bytes, parse_string};
+use crate::{RelationOp, ArithmeticOp, ExpressionInner, Expression, UnaryOp, Member, Atom, parse_bytes, parse_string};
 use std::sync::Arc;
 
 grammar;
@@ -12,63 +12,67 @@ match {
 }
 
 pub Expression: Expression = {
+    <start: @L> <inner: ExpressionInner> <end: @R> => Expression{span: Some(start..end), inner}
+};
+
+pub ExpressionInner: ExpressionInner = {
     Conditional
 };
 
-pub Conditional: Expression = {
-    <condition:LogicalOr> "?" <if_true:LogicalOr> ":" <if_false:Conditional> => Expression::Ternary(condition.into(), if_true.into(), if_false.into()),
+pub Conditional: ExpressionInner = {
+    <condition:LogicalOr> "?" <if_true:LogicalOr> ":" <if_false:Conditional> => ExpressionInner::Ternary(condition.into_expression().into(), if_true.into_expression().into(), if_false.into_expression().into()),
     LogicalOr
 };
 
-pub LogicalOr: Expression = {
-    <left:LogicalOr> "||" <right:LogicalAnd> => Expression::Or(left.into(), right.into()),
+pub LogicalOr: ExpressionInner = {
+    <left:LogicalOr> "||" <right:LogicalAnd> => ExpressionInner::Or(left.into_expression().into(), right.into_expression().into()),
     LogicalAnd
 };
 
-pub LogicalAnd: Expression = {
-    <left:LogicalAnd> "&&" <right:Relations> => Expression::And(left.into(), right.into()),
+pub LogicalAnd: ExpressionInner = {
+    <left:LogicalAnd> "&&" <right:Relations> => ExpressionInner::And(left.into_expression().into(), right.into_expression().into()),
     Relations
 };
 
-pub Relations: Expression = {
-    <left:ArithmeticAddSub> <op:RelationOp> <right:ArithmeticAddSub> => Expression::Relation(left.into(), op, right.into()),
+pub Relations: ExpressionInner = {
+    <left:ArithmeticAddSub> <op:RelationOp> <right:ArithmeticAddSub> => ExpressionInner::Relation(left.into_expression().into(), op, right.into_expression().into()),
     ArithmeticAddSub
 };
 
-pub ArithmeticAddSub: Expression = {
-    <left:ArithmeticAddSub> <op:ArithmeticOpAddSub> <right:ArithmeticMulDivMod> => Expression::Arithmetic(left.into(), op, right.into()),
+pub ArithmeticAddSub: ExpressionInner = {
+    <left:ArithmeticAddSub> <op:ArithmeticOpAddSub> <right:ArithmeticMulDivMod> => ExpressionInner::Arithmetic(left.into_expression().into(), op, right.into_expression().into()),
     ArithmeticMulDivMod
 };
 
-pub ArithmeticMulDivMod: Expression = {
-    <left:ArithmeticMulDivMod> <op:ArithmeticOpMulDivMod> <right:Unary> => Expression::Arithmetic(left.into(), op, right.into()),
+pub ArithmeticMulDivMod: ExpressionInner = {
+    <left:ArithmeticMulDivMod> <op:ArithmeticOpMulDivMod> <right:Unary> => ExpressionInner::Arithmetic(left.into_expression().into(), op, right.into_expression().into()),
     Unary
 };
 
-pub Unary: Expression = {
-    <op:UnaryOp> <right:Member> => Expression::Unary(op, right.into()),
+pub Unary: ExpressionInner = {
+    <op:UnaryOp> <right:Member> => ExpressionInner::Unary(op, right.into_expression().into()),
     Member
 };
 
-pub Member: Expression = {
-    <left:Member> "." <identifier:Ident> => Expression::Member(left.into(), Member::Attribute(identifier.into()).into()).into(),
+pub Member: ExpressionInner = {
+    <left:Member> "." <identifier:Ident> => ExpressionInner::Member(left.into_expression().into(), Member::Attribute(identifier.into()).into()).into(),
     <left:Member> "." <identifier:Ident> "(" <arguments:CommaSeparated<Expression>> ")" => {
-           Expression::FunctionCall(Expression::Ident(identifier).into(), Some(left.into()), arguments).into()
+           ExpressionInner::FunctionCall(ExpressionInner::Ident(identifier).into_expression().into(), Some(left.into_expression().into()), arguments).into()
    },
-    <left:Member> "[" <expression:Expression> "]" => Expression::Member(left.into(), Member::Index(expression.into()).into()).into(),
-    <left:Member> "{" <fields:CommaSeparated<FieldInits>> "}" => Expression::Member(left.into(), Member::Fields(fields.into()).into()).into(),
+    <left:Member> "[" <expression:Expression> "]" => ExpressionInner::Member(left.into_expression().into(), Member::Index(expression.into()).into()).into(),
+    <left:Member> "{" <fields:CommaSeparated<FieldInits>> "}" => ExpressionInner::Member(left.into_expression().into(), Member::Fields(fields.into()).into()).into(),
     Primary,
 }
 
-pub Primary: Expression = {
-    "."? <Ident> => Expression::Ident(<>.into()).into(),
+pub Primary: ExpressionInner = {
+    "."? <Ident> => ExpressionInner::Ident(<>.into()).into(),
     "."? <identifier:Ident> "(" <arguments:CommaSeparated<Expression>> ")" => {
-           Expression::FunctionCall(Expression::Ident(identifier).into(), None, arguments).into()
+           ExpressionInner::FunctionCall(ExpressionInner::Ident(identifier).into_expression().into(), None, arguments).into()
     },
-    Atom => Expression::Atom(<>).into(),
-    "[" <members:CommaSeparated<Expression>> "]" => Expression::List(<>).into(),
-    "{" <fields:CommaSeparated<MapInits>> "}" => Expression::Map(<>).into(),
-    "(" <Expression> ")"
+    Atom => ExpressionInner::Atom(<>).into(),
+    "[" <members:CommaSeparated<Expression>> "]" => ExpressionInner::List(<>).into(),
+    "{" <fields:CommaSeparated<MapInits>> "}" => ExpressionInner::Map(<>).into(),
+    "(" <ExpressionInner> ")"
 }
 
 pub FieldInits: (Arc<String>, Expression) = {

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -1,4 +1,4 @@
-use crate::{RelationOp, ArithmeticOp, ExpressionInner, Expression, UnaryOp, Member, Atom, parse_bytes, parse_string};
+use crate::{RelationOp, ArithmeticOp, Expression, SpannedExpression, Spanned, SpanExtension, UnaryOp, Member, Atom, parse_bytes, parse_string};
 use std::sync::Arc;
 
 grammar;
@@ -11,76 +11,76 @@ match {
    _
 }
 
-pub Expression: Expression = {
-    <start: @L> <inner: ExpressionInner> <end: @R> => Expression{span: Some(start..end), inner}
+pub SpannedExpression: Spanned<Expression> = {
+    <start: @L> <inner: Expression> <end: @R> => inner.spanned(start..end)
 };
 
-pub ExpressionInner: ExpressionInner = {
+pub Expression: Expression = {
     Conditional
 };
 
-pub Conditional: ExpressionInner = {
-    <condition:LogicalOr> "?" <if_true:LogicalOr> ":" <if_false:Conditional> => ExpressionInner::Ternary(condition.into_expression().into(), if_true.into_expression().into(), if_false.into_expression().into()),
+pub Conditional: Expression = {
+    <condition:LogicalOr> "?" <if_true:LogicalOr> ":" <if_false:Conditional> => Expression::Ternary(condition.unspanned().into(), if_true.unspanned().into(), if_false.unspanned().into()),
     LogicalOr
 };
 
-pub LogicalOr: ExpressionInner = {
-    <left:LogicalOr> "||" <right:LogicalAnd> => ExpressionInner::Or(left.into_expression().into(), right.into_expression().into()),
+pub LogicalOr: Expression = {
+    <left:LogicalOr> "||" <right:LogicalAnd> => Expression::Or(left.unspanned().into(), right.unspanned().into()),
     LogicalAnd
 };
 
-pub LogicalAnd: ExpressionInner = {
-    <left:LogicalAnd> "&&" <right:Relations> => ExpressionInner::And(left.into_expression().into(), right.into_expression().into()),
+pub LogicalAnd: Expression = {
+    <left:LogicalAnd> "&&" <right:Relations> => Expression::And(left.unspanned().into(), right.unspanned().into()),
     Relations
 };
 
-pub Relations: ExpressionInner = {
-    <left:ArithmeticAddSub> <op:RelationOp> <right:ArithmeticAddSub> => ExpressionInner::Relation(left.into_expression().into(), op, right.into_expression().into()),
+pub Relations: Expression = {
+    <left:ArithmeticAddSub> <op:RelationOp> <right:ArithmeticAddSub> => Expression::Relation(left.unspanned().into(), op, right.unspanned().into()),
     ArithmeticAddSub
 };
 
-pub ArithmeticAddSub: ExpressionInner = {
-    <left:ArithmeticAddSub> <op:ArithmeticOpAddSub> <right:ArithmeticMulDivMod> => ExpressionInner::Arithmetic(left.into_expression().into(), op, right.into_expression().into()),
+pub ArithmeticAddSub: Expression = {
+    <left:ArithmeticAddSub> <op:ArithmeticOpAddSub> <right:ArithmeticMulDivMod> => Expression::Arithmetic(left.unspanned().into(), op, right.unspanned().into()),
     ArithmeticMulDivMod
 };
 
-pub ArithmeticMulDivMod: ExpressionInner = {
-    <left:ArithmeticMulDivMod> <op:ArithmeticOpMulDivMod> <right:Unary> => ExpressionInner::Arithmetic(left.into_expression().into(), op, right.into_expression().into()),
+pub ArithmeticMulDivMod: Expression = {
+    <left:ArithmeticMulDivMod> <op:ArithmeticOpMulDivMod> <right:Unary> => Expression::Arithmetic(left.unspanned().into(), op, right.unspanned().into()),
     Unary
 };
 
-pub Unary: ExpressionInner = {
-    <op:UnaryOp> <right:Member> => ExpressionInner::Unary(op, right.into_expression().into()),
+pub Unary: Expression = {
+    <op:UnaryOp> <right:Member> => Expression::Unary(op, right.unspanned().into()),
     Member
 };
 
-pub Member: ExpressionInner = {
-    <left:Member> "." <identifier:Ident> => ExpressionInner::Member(left.into_expression().into(), Member::Attribute(identifier.into()).into()).into(),
-    <left:Member> "." <identifier:Ident> "(" <arguments:CommaSeparated<Expression>> ")" => {
-           ExpressionInner::FunctionCall(ExpressionInner::Ident(identifier).into_expression().into(), Some(left.into_expression().into()), arguments).into()
+pub Member: Expression = {
+    <left:Member> "." <identifier:Ident> => Expression::Member(left.unspanned().into(), Member::Attribute(identifier.into()).into()).into(),
+    <left:Member> "." <identifier:Ident> "(" <arguments:CommaSeparated<SpannedExpression>> ")" => {
+           Expression::FunctionCall(Expression::Ident(identifier).unspanned().into(), Some(left.unspanned().into()), arguments).into()
    },
-    <left:Member> "[" <expression:Expression> "]" => ExpressionInner::Member(left.into_expression().into(), Member::Index(expression.into()).into()).into(),
-    <left:Member> "{" <fields:CommaSeparated<FieldInits>> "}" => ExpressionInner::Member(left.into_expression().into(), Member::Fields(fields.into()).into()).into(),
+    <left:Member> "[" <expression:SpannedExpression> "]" => Expression::Member(left.unspanned().into(), Member::Index(expression.into()).into()).into(),
+    <left:Member> "{" <fields:CommaSeparated<FieldInits>> "}" => Expression::Member(left.unspanned().into(), Member::Fields(fields.into()).into()).into(),
     Primary,
 }
 
-pub Primary: ExpressionInner = {
-    "."? <Ident> => ExpressionInner::Ident(<>.into()).into(),
-    "."? <identifier:Ident> "(" <arguments:CommaSeparated<Expression>> ")" => {
-           ExpressionInner::FunctionCall(ExpressionInner::Ident(identifier).into_expression().into(), None, arguments).into()
+pub Primary: Expression = {
+    "."? <Ident> => Expression::Ident(<>.into()).into(),
+    "."? <identifier:Ident> "(" <arguments:CommaSeparated<SpannedExpression>> ")" => {
+           Expression::FunctionCall(Expression::Ident(identifier).unspanned().into(), None, arguments).into()
     },
-    Atom => ExpressionInner::Atom(<>).into(),
-    "[" <members:CommaSeparated<Expression>> "]" => ExpressionInner::List(<>).into(),
-    "{" <fields:CommaSeparated<MapInits>> "}" => ExpressionInner::Map(<>).into(),
-    "(" <ExpressionInner> ")"
+    Atom => Expression::Atom(<>).into(),
+    "[" <members:CommaSeparated<SpannedExpression>> "]" => Expression::List(<>).into(),
+    "{" <fields:CommaSeparated<MapInits>> "}" => Expression::Map(<>).into(),
+    "(" <Expression> ")"
 }
 
-pub FieldInits: (Arc<String>, Expression) = {
-    <Ident> ":" <Expression>
+pub FieldInits: (Arc<Spanned<String>>, SpannedExpression) = {
+    <Ident> ":" <SpannedExpression>
 }
 
-pub MapInits: (Expression, Expression) = {
-    <Expression> ":" <Expression>
+pub MapInits: (SpannedExpression, SpannedExpression) = {
+    <SpannedExpression> ":" <SpannedExpression>
 }
 
 CommaSeparated<T>: Vec<T> = {
@@ -171,6 +171,6 @@ Atom: Atom = {
     "null" => Atom::Null,
 };
 
-Ident: Arc<String> = {
-    r"[_a-zA-Z][_a-zA-Z0-9]*" => Arc::from(<>.to_string())
+Ident: Arc<Spanned<String>> = {
+    <start: @L> <s: r"[_a-zA-Z][_a-zA-Z0-9]*"> <end: @R> => Arc::from(s.to_string().spanned(start..end))
 }

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -12,66 +12,66 @@ match {
 }
 
 pub SpannedExpression: Spanned<Expression> = {
-    <start: @L> <inner: Expression> <end: @R> => inner.spanned(start..end)
+    Expression
 };
 
-pub Expression: Expression = {
+pub Expression: Spanned<Expression> = {
     Conditional
 };
 
-pub Conditional: Expression = {
-    <condition:LogicalOr> "?" <if_true:LogicalOr> ":" <if_false:Conditional> => Expression::Ternary(condition.unspanned().into(), if_true.unspanned().into(), if_false.unspanned().into()),
+pub Conditional: Spanned<Expression> = {
+    <start: @L> <condition:LogicalOr> "?" <if_true:LogicalOr> ":" <if_false:Conditional> <end: @R> => Expression::Ternary(condition.into(), if_true.into(), if_false.into()).spanned(start..end),
     LogicalOr
 };
 
-pub LogicalOr: Expression = {
-    <left:LogicalOr> "||" <right:LogicalAnd> => Expression::Or(left.unspanned().into(), right.unspanned().into()),
+pub LogicalOr: Spanned<Expression> = {
+    <start: @L> <left:LogicalOr> "||" <right:LogicalAnd> <end: @R> => Expression::Or(left.into(), right.into()).spanned(start..end),
     LogicalAnd
 };
 
-pub LogicalAnd: Expression = {
-    <left:LogicalAnd> "&&" <right:Relations> => Expression::And(left.unspanned().into(), right.unspanned().into()),
+pub LogicalAnd: Spanned<Expression> = {
+    <start: @L> <left:LogicalAnd> "&&" <right:Relations> <end: @R> => Expression::And(left.into(), right.into()).spanned(start..end),
     Relations
 };
 
-pub Relations: Expression = {
-    <left:ArithmeticAddSub> <op:SpannedRelationOp> <right:ArithmeticAddSub> => Expression::Relation(left.unspanned().into(), op, right.unspanned().into()),
+pub Relations: Spanned<Expression> = {
+    <start: @L> <left:ArithmeticAddSub> <op:SpannedRelationOp> <right:ArithmeticAddSub> <end: @R> => Expression::Relation(left.into(), op, right.into()).spanned(start..end),
     ArithmeticAddSub
 };
 
-pub ArithmeticAddSub: Expression = {
-    <left:ArithmeticAddSub> <op:SpannedArithmeticOpAddSub> <right:ArithmeticMulDivMod> => Expression::Arithmetic(left.unspanned().into(), op, right.unspanned().into()),
+pub ArithmeticAddSub: Spanned<Expression> = {
+    <start: @L> <left:ArithmeticAddSub> <op:SpannedArithmeticOpAddSub> <right:ArithmeticMulDivMod> <end: @R> => Expression::Arithmetic(left.into(), op, right.into()).spanned(start..end),
     ArithmeticMulDivMod
 };
 
-pub ArithmeticMulDivMod: Expression = {
-    <left:ArithmeticMulDivMod> <op:SpannedArithmeticOpMulDivMod> <right:Unary> => Expression::Arithmetic(left.unspanned().into(), op, right.unspanned().into()),
+pub ArithmeticMulDivMod: Spanned<Expression> = {
+    <start: @L> <left:ArithmeticMulDivMod> <op:SpannedArithmeticOpMulDivMod> <right:Unary> <end: @R> => Expression::Arithmetic(left.into(), op, right.into()).spanned(start..end),
     Unary
 };
 
-pub Unary: Expression = {
-    <op:SpannedUnaryOp> <right:Member> => Expression::Unary(op, right.unspanned().into()),
+pub Unary: Spanned<Expression> = {
+    <start: @L> <op:SpannedUnaryOp> <right:Member> <end: @R> => Expression::Unary(op, right.into()).spanned(start..end),
     Member
 };
 
-pub Member: Expression = {
-    <left:Member> "." <identifier:Ident> => Expression::Member(left.unspanned().into(), Member::Attribute(identifier.into()).into()).into(),
-    <left:Member> "." <identifier:Ident> "(" <arguments:CommaSeparated<SpannedExpression>> ")" => {
-           Expression::FunctionCall(Expression::Ident(identifier).unspanned().into(), Some(left.unspanned().into()), arguments).into()
+pub Member: Spanned<Expression> = {
+    <start: @L> <left:Member> "." <identifier:Ident> <end: @R> => Expression::Member(left.into(), Member::Attribute(identifier.into()).into()).spanned(start..end),
+    <start: @L> <left:Member> "." <identifier:ExprIdent> "(" <arguments:CommaSeparated<SpannedExpression>> ")" <end: @R> => {
+           Expression::FunctionCall(identifier.into(), Some(left.into()), arguments).spanned(start..end)
    },
-    <left:Member> "[" <expression:SpannedExpression> "]" => Expression::Member(left.unspanned().into(), Member::Index(expression.into()).into()).into(),
-    <left:Member> "{" <fields:CommaSeparated<FieldInits>> "}" => Expression::Member(left.unspanned().into(), Member::Fields(fields.into()).into()).into(),
+    <start: @L> <left:Member> "[" <expression:SpannedExpression> "]" <end: @R> => Expression::Member(left.into(), Member::Index(expression.into()).into()).spanned(start..end),
+    <start: @L> <left:Member> "{" <fields:CommaSeparated<FieldInits>> "}" <end: @R> => Expression::Member(left.into(), Member::Fields(fields.into()).into()).spanned(start..end),
     Primary,
 }
 
-pub Primary: Expression = {
-    "."? <Ident> => Expression::Ident(<>.into()).into(),
-    "."? <identifier:Ident> "(" <arguments:CommaSeparated<SpannedExpression>> ")" => {
-           Expression::FunctionCall(Expression::Ident(identifier).unspanned().into(), None, arguments).into()
+pub Primary: Spanned<Expression> = {
+    <start: @L> "."? <id: Ident> <end: @R> => Expression::Ident(id.into()).spanned(start..end),
+    <start: @L> "."? <identifier:ExprIdent> "(" <arguments:CommaSeparated<SpannedExpression>> ")" <end: @R> => {
+           Expression::FunctionCall(identifier.into(), None, arguments).spanned(start..end)
     },
-    Atom => Expression::Atom(<>).into(),
-    "[" <members:CommaSeparated<SpannedExpression>> "]" => Expression::List(<>).into(),
-    "{" <fields:CommaSeparated<MapInits>> "}" => Expression::Map(<>).into(),
+    <start: @L> <a: Atom> <end: @R> => Expression::Atom(a).spanned(start..end),
+    <start: @L> "[" <members:CommaSeparated<SpannedExpression>> "]" <end: @R> => Expression::List(members).spanned(start..end),
+    <start: @L> "{" <fields:CommaSeparated<MapInits>> "}" <end: @R> => Expression::Map(fields).spanned(start..end),
     "(" <Expression> ")"
 }
 
@@ -186,6 +186,10 @@ Atom: Atom = {
     "false" => Atom::Bool(false),
     "null" => Atom::Null,
 };
+
+ExprIdent: Spanned<Expression> = {
+    <start: @L> <id: Ident> <end: @R> => Expression::Ident(id).spanned(start..end)
+}
 
 Ident: Arc<Spanned<String>> = {
     <start: @L> <s: r"[_a-zA-Z][_a-zA-Z0-9]*"> <end: @R> => Arc::from(s.to_string().spanned(start..end))

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -35,22 +35,22 @@ pub LogicalAnd: Expression = {
 };
 
 pub Relations: Expression = {
-    <left:ArithmeticAddSub> <op:RelationOp> <right:ArithmeticAddSub> => Expression::Relation(left.unspanned().into(), op, right.unspanned().into()),
+    <left:ArithmeticAddSub> <op:SpannedRelationOp> <right:ArithmeticAddSub> => Expression::Relation(left.unspanned().into(), op, right.unspanned().into()),
     ArithmeticAddSub
 };
 
 pub ArithmeticAddSub: Expression = {
-    <left:ArithmeticAddSub> <op:ArithmeticOpAddSub> <right:ArithmeticMulDivMod> => Expression::Arithmetic(left.unspanned().into(), op, right.unspanned().into()),
+    <left:ArithmeticAddSub> <op:SpannedArithmeticOpAddSub> <right:ArithmeticMulDivMod> => Expression::Arithmetic(left.unspanned().into(), op, right.unspanned().into()),
     ArithmeticMulDivMod
 };
 
 pub ArithmeticMulDivMod: Expression = {
-    <left:ArithmeticMulDivMod> <op:ArithmeticOpMulDivMod> <right:Unary> => Expression::Arithmetic(left.unspanned().into(), op, right.unspanned().into()),
+    <left:ArithmeticMulDivMod> <op:SpannedArithmeticOpMulDivMod> <right:Unary> => Expression::Arithmetic(left.unspanned().into(), op, right.unspanned().into()),
     Unary
 };
 
 pub Unary: Expression = {
-    <op:UnaryOp> <right:Member> => Expression::Unary(op, right.unspanned().into()),
+    <op:SpannedUnaryOp> <right:Member> => Expression::Unary(op, right.unspanned().into()),
     Member
 };
 
@@ -94,9 +94,17 @@ CommaSeparated<T>: Vec<T> = {
     }
 };
 
+SpannedArithmeticOpAddSub: Spanned<ArithmeticOp> = {
+    <start: @L> <op: ArithmeticOpAddSub> <end: @R> => op.spanned(start..end)
+};
+
 ArithmeticOpAddSub: ArithmeticOp = {
     "+" => ArithmeticOp::Add,
     "-" => ArithmeticOp::Subtract
+};
+
+SpannedArithmeticOpMulDivMod: Spanned<ArithmeticOp> = {
+    <start: @L> <op: ArithmeticOpMulDivMod> <end: @R> => op.spanned(start..end)
 };
 
 ArithmeticOpMulDivMod: ArithmeticOp = {
@@ -106,12 +114,20 @@ ArithmeticOpMulDivMod: ArithmeticOp = {
 };
 
 
+SpannedUnaryOp: Spanned<UnaryOp> = {
+    <start: @L> <op: UnaryOp> <end: @R> => op.spanned(start..end)
+};
+
 UnaryOp: UnaryOp = {
     "!" => UnaryOp::Not,
     "!!" => UnaryOp::DoubleNot,
     "-" => UnaryOp::Minus,
     "--" => UnaryOp::DoubleMinus,
-}
+};
+
+SpannedRelationOp: Spanned<RelationOp> = {
+    <start: @L> <op: RelationOp> <end: @R> => op.spanned(start..end)
+};
 
 RelationOp: RelationOp = {
     "<" => RelationOp::LessThan,
@@ -121,7 +137,7 @@ RelationOp: RelationOp = {
     "==" => RelationOp::Equals,
     "!=" => RelationOp::NotEquals,
     "in" => RelationOp::In
-}
+};
 
 Atom: Atom = {
     // Integer literals. Annoying to parse :/

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -581,4 +581,38 @@ mod tests {
         assert_eq!(err.span.end.as_ref().unwrap().line, 1);
         assert_eq!(err.span.end.as_ref().unwrap().column, 31);
     }
+
+    #[test]
+    fn spanned_expressions() {
+        assert_eq!(parse("5"), Expression::Atom(Atom::Int(5)).spanned(0..1));
+        assert_eq!(
+            parse("5 + 4"),
+            Expression::Arithmetic(
+                Box::new(Expression::Atom(Atom::Int(5)).spanned(0..1)),
+                ArithmeticOp::Add.spanned(2..3),
+                Box::new(Expression::Atom(Atom::Int(4)).spanned(4..5))
+            )
+            .spanned(0..5)
+        );
+
+        assert_eq!(
+            parse("5+4"),
+            Expression::Arithmetic(
+                Box::new(Expression::Atom(Atom::Int(5)).spanned(0..1)),
+                ArithmeticOp::Add.spanned(1..2),
+                Box::new(Expression::Atom(Atom::Int(4)).spanned(2..3))
+            )
+            .spanned(0..3)
+        );
+
+        assert_eq!(
+            parse("5 +      4"),
+            Expression::Arithmetic(
+                Box::new(Expression::Atom(Atom::Int(5)).spanned(0..1)),
+                ArithmeticOp::Add.spanned(2..3),
+                Box::new(Expression::Atom(Atom::Int(4)).spanned(9..10))
+            )
+            .spanned(0..10)
+        );
+    }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -618,7 +618,7 @@ mod span_tests {
     }
 
     #[test]
-    fn spanned_expressions() {
+    fn spanned_arithmatic() {
         assert_span!(parse("5 + 4"), 0..5);
 
         assert_matches!(parse("5 + 4").inner, Expression::Arithmetic(five, plus, four) => {
@@ -638,7 +638,15 @@ mod span_tests {
             assert_span!(plus, 2..3);
             assert_span!(four, 8..9);
         });
+    }
 
+    #[test]
+    fn spanned_relation() {
+        assert_span!(parse("5 == 4"), 0..6);
+    }
+
+    #[test]
+    fn spanned_ternary() {
         assert_matches!(parse("true ? 4 : 5").inner, Expression::Ternary(i, t, e) => {
                 assert_span!(i, 0..4);
                 assert_span!(t, 7..8);
@@ -653,6 +661,16 @@ mod span_tests {
         assert_span!(ident, 0..8);
         assert_matches!(ident.inner, Expression::Ident(my_ident) => {
             assert_span!(my_ident, 0..8);
+        })
+    }
+
+    #[test]
+    fn spanned_unary() {
+        let ident = parse("-my_ident");
+        assert_span!(ident, 0..9);
+        assert_matches!(ident.inner, Expression::Unary(op, target) => {
+            assert_span!(op, 0..1);
+            assert_span!(target, 1..9);
         })
     }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -614,5 +614,15 @@ mod tests {
             )
             .spanned(0..10)
         );
+
+        assert_eq!(
+            parse("true ? 4 : 5"),
+            Expression::Ternary(
+                Box::new(Expression::Atom(Atom::Bool(true)).spanned(0..4)),
+                Box::new(Expression::Atom(Atom::Int(4)).spanned(7..8)),
+                Box::new(Expression::Atom(Atom::Int(5)).spanned(11..12)),
+            )
+            .spanned(0..12)
+        );
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -19,7 +19,7 @@ lalrpop_mod!(#[allow(clippy::all)] pub parser, "/cel.rs");
 /// let expr = parse("1 + 1").unwrap();
 /// println!("{:?}", expr);
 /// ```
-pub fn parse(input: &str) -> Result<SpannedExpression, ParseError> {
+pub fn parse(input: &str) -> Result<Spanned<Expression>, ParseError> {
     // Wrap the internal parser function - whether larlpop or chumsky
 
     // Example for a possible new chumsky based parser...
@@ -44,10 +44,10 @@ mod tests {
         Atom::{self, *},
         Expression::{self, *},
         Member::*,
-        RelationOp, SpanExtension, SpannedExpression, UnaryOp,
+        RelationOp, SpanExtension, Spanned, UnaryOp,
     };
 
-    fn parse(input: &str) -> SpannedExpression {
+    fn parse(input: &str) -> Spanned<Expression> {
         crate::parse(input).unwrap_or_else(|e| panic!("{}", e))
     }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -148,7 +148,7 @@ mod tests {
                     Ident("x".to_string().unspanned().into()).unspanned(),
                     Arithmetic(
                         Box::new(Ident("x".to_string().unspanned().into()).unspanned()),
-                        ArithmeticOp::Multiply,
+                        ArithmeticOp::Multiply.unspanned(),
                         Box::new(Atom(Int(2)).unspanned()),
                     )
                     .unspanned(),
@@ -190,14 +190,14 @@ mod tests {
         assert_parse_eq(
             "!false",
             Unary(
-                UnaryOp::Not,
+                UnaryOp::Not.unspanned(),
                 Box::new(Expression::Atom(Atom::Bool(false)).unspanned()),
             ),
         );
         assert_parse_eq(
             "!true",
             Unary(
-                UnaryOp::Not,
+                UnaryOp::Not.unspanned(),
                 Box::new(Expression::Atom(Atom::Bool(true)).unspanned()),
             ),
         );
@@ -209,7 +209,7 @@ mod tests {
             "true == true",
             Relation(
                 Box::new(Expression::Atom(Atom::Bool(true)).unspanned()),
-                RelationOp::Equals,
+                RelationOp::Equals.unspanned(),
                 Box::new(Expression::Atom(Atom::Bool(true)).unspanned()),
             ),
         );
@@ -220,7 +220,7 @@ mod tests {
         assert_eq!(
             parse("!!true"),
             (Unary(
-                UnaryOp::DoubleNot,
+                UnaryOp::DoubleNot.unspanned(),
                 Box::new(Expression::Atom(Atom::Bool(true)).unspanned()),
             )
             .unspanned())
@@ -232,7 +232,7 @@ mod tests {
         assert_parse_eq(
             "(-((1)))",
             Unary(
-                UnaryOp::Minus,
+                UnaryOp::Minus.unspanned(),
                 Box::new(Expression::Atom(Atom::Int(1)).unspanned()),
             ),
         );
@@ -309,7 +309,7 @@ mod tests {
             "2 in [2]",
             Relation(
                 Box::new(Expression::Atom(Int(2)).unspanned()),
-                RelationOp::In,
+                RelationOp::In.unspanned(),
                 Box::new(List(vec![Expression::Atom(Int(2)).unspanned()]).unspanned()),
             ),
         );
@@ -366,7 +366,7 @@ mod tests {
             "2 != 3",
             Relation(
                 Box::new(Expression::Atom(Int(2)).unspanned()),
-                RelationOp::NotEquals,
+                RelationOp::NotEquals.unspanned(),
                 Box::new(Expression::Atom(Int(3)).unspanned()),
             ),
         );
@@ -374,7 +374,7 @@ mod tests {
             "2 == 3",
             Relation(
                 Box::new(Expression::Atom(Int(2)).unspanned()),
-                RelationOp::Equals,
+                RelationOp::Equals.unspanned(),
                 Box::new(Expression::Atom(Int(3)).unspanned()),
             ),
         );
@@ -383,7 +383,7 @@ mod tests {
             "2 < 3",
             Relation(
                 Box::new(Expression::Atom(Int(2)).unspanned()),
-                RelationOp::LessThan,
+                RelationOp::LessThan.unspanned(),
                 Box::new(Expression::Atom(Int(3)).unspanned()),
             ),
         );
@@ -392,7 +392,7 @@ mod tests {
             "2 <= 3",
             Relation(
                 Box::new(Expression::Atom(Int(2)).unspanned()),
-                RelationOp::LessThanEq,
+                RelationOp::LessThanEq.unspanned(),
                 Box::new(Expression::Atom(Int(3)).unspanned()),
             ),
         );
@@ -404,7 +404,7 @@ mod tests {
             "2 * 3",
             Arithmetic(
                 Box::new(Expression::Atom(Atom::Int(2)).unspanned()),
-                ArithmeticOp::Multiply,
+                ArithmeticOp::Multiply.unspanned(),
                 Box::new(Expression::Atom(Atom::Int(3)).unspanned()),
             ),
         );
@@ -443,7 +443,7 @@ mod tests {
             "2 + 3",
             Arithmetic(
                 Box::new(Expression::Atom(Atom::Int(2)).unspanned()),
-                ArithmeticOp::Add,
+                ArithmeticOp::Add.unspanned(),
                 Box::new(Expression::Atom(Atom::Int(3)).unspanned()),
             ),
         );
@@ -520,7 +520,7 @@ mod tests {
                 Box::new(
                     Relation(
                         Box::new(Ident("b".to_string().unspanned().into()).unspanned()),
-                        RelationOp::Equals,
+                        RelationOp::Equals.unspanned(),
                         Box::new(Expression::Atom(String("string".to_string().into())).unspanned()),
                     )
                     .unspanned(),


### PR DESCRIPTION
For some use cases (for example https://github.com/Ichmed/sqcel) it would be nice to have span information to produce nice error messages when a CEL expression is syntactically correct but semantically wrong.

Please leave a comment if this is desirable before i make the effort to add spans to all other types.