### PR TITLE
Optimizations around member lookups

### DIFF
--- a/interpreter/benches/runtime.rs
+++ b/interpreter/benches/runtime.rs
@@ -27,6 +27,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         ("size_str_2", "size('a')"),
         ("size_map", "{1:2}.size()"),
         ("size_map_2", "size({1:2})"),
+        ("member", "foo.bar"),
         ("map has", "has(foo.bar.baz)"),
         ("map macro", "[1, 2, 3].map(x, x * 2)"),
         ("filter macro", "[1, 2, 3].filter(x, x > 2)"),

--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -78,7 +78,7 @@ impl Context<'_> {
 
     pub fn get_variable<S>(&self, name: S) -> Result<Value, ExecutionError>
     where
-      S: AsRef<str>
+        S: AsRef<str>,
     {
         let name = name.as_ref();
         match self {

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -733,12 +733,10 @@ impl Value {
         // to see if the next token is a function call?
         if let Some(child) = child {
             child.into()
+        } else if ctx.has_function(&name) {
+            Value::Function(name.clone(), Some(self.into())).into()
         } else {
-            if ctx.has_function(&name) {
-                Value::Function(name.clone(), Some(self.into())).into()
-            } else {
-                ExecutionError::NoSuchKey(name.clone()).into()
-            }
+            ExecutionError::NoSuchKey(name.clone()).into()
         }
     }
 

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -731,10 +731,14 @@ impl Value {
         // If the property is both an attribute and a method, then we
         // give priority to the property. Maybe we can implement lookahead
         // to see if the next token is a function call?
-        match (child, ctx.has_function(&name)) {
-            (None, false) => ExecutionError::NoSuchKey(name).into(),
-            (Some(child), _) => child.into(),
-            (None, true) => Value::Function(name, Some(self.into())).into(),
+        if let Some(child) = child {
+            child.into()
+        } else {
+            if ctx.has_function(&name) {
+                Value::Function(name.clone(), Some(self.into())).into()
+            } else {
+                ExecutionError::NoSuchKey(name.clone()).into()
+            }
         }
     }
 

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -129,7 +129,7 @@ impl TryInto<Key> for Value {
 // Implement conversion from HashMap<K, V> into CelMap
 impl<K: Into<Key>, V: Into<Value>> From<HashMap<K, V>> for Map {
     fn from(map: HashMap<K, V>) -> Self {
-        let mut new_map = HashMap::new();
+        let mut new_map = HashMap::with_capacity(map.len());
         for (k, v) in map {
             new_map.insert(k.into(), v.into());
         }
@@ -655,7 +655,7 @@ impl Value {
                 Value::List(list.into()).into()
             }
             Expr::Map(map_expr) => {
-                let mut map = HashMap::default();
+                let mut map = HashMap::with_capacity(map_expr.entries.len());
                 for entry in map_expr.entries.iter() {
                     let (k, v) = match &entry.expr {
                         EntryExpr::StructField(_) => panic!("WAT?"),


### PR DESCRIPTION
1. Do not call has_function unless we need to. Drops about 20ns
2. Do not convert string on member lookup. Drops about 5ns
3. Add missing benchmark for member lookup
4. Make hashmaps pre-sized to the final size; no impact on the benchmark here but probably would have an impact on large maps?