### PR TITLE
Make Program expose the Expression

### DIFF
--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -177,6 +177,11 @@ impl Program {
     pub fn references(&self) -> ExpressionReferences {
         self.expression.references()
     }
+
+    /// Returns the contained expression
+    pub fn expression(&self) -> &Expression {
+        &self.expression
+    }
 }
 
 impl TryFrom<&str> for Program {


### PR DESCRIPTION
Program, at least today, appears to purely be a thin convenience wrapper around IdedExpr (Expression) - everything it can do, you can do yourself.

I have a use case that benefits from inspecting the AST (in short, memoizing that certain expressions can never evaluate certain ways - think basically partial evaluation, given these particular values, but with everything else unknown).
Now, obviously I can do without this; it just requires basically including my own version of Program in my program.
But given that everything Program exposes is already public - and therefore, anything that changes this particular field would be a semver change anyway - I don't see a great reason not to allow getting a const reference to the contained Expression. If this later changes, that's ok, it'll be no more breaking that if folks used Expression directly.