### PR TITLE
perf: ExpressionReferences::variables and ExpressionReferences::functions should return iterators

### DIFF
--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -249,7 +249,7 @@ mod tests {
     fn references() {
         let p = Program::compile("[1, 1].map(x, x * 2)").unwrap();
         assert!(p.references().has_variable("x"));
-        assert_eq!(p.references().variables().len(), 1);
+        assert_eq!(p.references().variables().collect::<Vec<&str>>(), ["x"]);
     }
 
     #[test]

--- a/cel/src/parser/references.rs
+++ b/cel/src/parser/references.rs
@@ -30,36 +30,50 @@ impl ExpressionReferences<'_> {
     /// let expression = Parser::new().parse("size(foo) > 0").unwrap();
     /// let references = expression.references();
     /// assert!(references.has_function("size"));
+    /// assert!(references.has_function("_>_"))
     /// ```
     pub fn has_function(&self, name: impl AsRef<str>) -> bool {
         self.functions.contains(name.as_ref())
     }
 
-    /// Returns a list of all variables referenced in the expression.
+    /// Returns an iterator over all variables referenced in the expression.
     ///
+    /// Note: [`Self::has_variable`] is a more efficient way to test for the presense of variables.
+    /// Use this function only if you need to iterate over all variables referenced in this expression.
     /// # Example
+    ///
     /// ```rust
     /// # use cel::parser::Parser;
-    /// let expression = Parser::new().parse("foo.bar == true").unwrap();
+    /// let expression = Parser::new().parse("foo.bar == true && bar.baz == false && zzz.bar == false").unwrap();
     /// let references = expression.references();
-    /// assert_eq!(vec!["foo"], references.variables());
+    /// let mut variables = references.variables().collect::<Vec<_>>();
+    /// variables.sort();
+    /// assert_eq!(vec!["bar", "foo", "zzz"], variables);
     /// ```
-    pub fn variables(&self) -> Vec<&str> {
-        self.variables.iter().copied().collect()
+    pub fn variables(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.variables.iter().copied()
     }
 
-    /// Returns a list of all functions referenced in the expression.
+    /// Returns an iterator over all functions referenced in the expression.
+    ///
+    /// Note: [`Self::has_function`] is a more efficient way to test for the presense of functions.
+    /// Use this function only if you need to iterate over all functions referenced in this expression.
     ///
     /// # Example
     /// ```rust
     /// # use cel::parser::Parser;
+    /// # use std::collections::BTreeSet;
     /// let expression = Parser::new().parse("size(foo) > 0").unwrap();
     /// let references = expression.references();
-    /// assert!(references.functions().contains(&"_>_"));
-    /// assert!(references.functions().contains(&"size"));
+    /// for function in references.functions()
+    /// {
+    ///     println!("{function}");
+    /// }
+    /// let all_functions: BTreeSet<&str> = references.functions().collect();
+    /// assert_eq!(all_functions, BTreeSet::from(["_>_", "size"]));
     /// ```
-    pub fn functions(&self) -> Vec<&str> {
-        self.functions.iter().copied().collect()
+    pub fn functions(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.functions.iter().copied()
     }
 }
 


### PR DESCRIPTION
The main scenarios where you should use ```ExpressionReferences::variables``` and ```ExpressionReferences::functions``` are if you want to access _every_ variable or _every_ function.

If you have a list of n functions or variables you want to know if are used in an expression, you should probably just use ```has_variable``` or ```has_function``` - even if you have to call it n times, each of those lookups is O(1) and requires zero allocations. 

But if you do need to enumerate the variables or functions, the current implementation has some drawbacks I think this is a clear pessimization:
1. If you're only going to iterate over the variables or functions once using that vector (not retaining it), which I strongly suspect is common, it's forcing short-lived heap allocations and unnecessary copying of &str into the vector.
2. While in most cases the `has_` methods are preferable anyway, it limits your ability to choose other collections efficiently in scenarios where you don't. E.g. if you want a HashSet or BTreeSet (for intersecting, sorting, merge-joining, whatever), the Vec is just wasted.

What's more, the examples were a bit misleading; the one for ```ExpressionReferences::functions``` would be much more efficiently achieved via ```ExpressionReferences::has_function```
So improve the docs & doctests a bit.

This is a semver change; code using these two functions might no longer compile.
The change required to callers, however, is incredibly minimal.
If you called ```.functions()``` or ```.variables()```,  and do need a Vec, simply use ```.functions().collect::<Vec<&str>>()``` or  ```.variables().collect::<Vec<&str>>()``` instead.
In the case where you use it in a for loop or elsewhere (i.e. you just iterated over it anyway), I believe it will likely compile without changes.