### PR TITLE
Emerge a new public API

### DIFF
--- a/cel/src/common/ast/mod.rs
+++ b/cel/src/common/ast/mod.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 pub mod operators;
 
 pub struct Ast {
-    pub expr: IdedExpr,
+    pub(crate) expr: IdedExpr,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/cel/src/common/decls.rs
+++ b/cel/src/common/decls.rs
@@ -1,0 +1,20 @@
+use crate::common::functions;
+use crate::common::types::Type;
+use std::collections::HashMap;
+
+pub struct FunctionDecl<'a> {
+    name: String,
+    overloads: HashMap<String, OverloadDecl<'a>>,
+}
+
+pub struct OverloadDecl<'a> {
+    id: String,
+    arg_types: Vec<Type<'a>>,
+    result_type: Type<'a>,
+    member_function: bool,
+    // non_strict: bool,
+    // operand_trait: u16,
+    unary_op: Option<Box<functions::UnaryOp>>,
+    binary_op: Option<Box<functions::BinaryOp>>,
+    function_op: Option<Box<functions::FunctionOp>>,
+}

--- a/cel/src/common/functions.rs
+++ b/cel/src/common/functions.rs
@@ -1,0 +1,7 @@
+use crate::common::reference::CelVal;
+
+pub type UnaryOp = dyn Fn(&CelVal) -> CelVal;
+
+pub type BinaryOp = dyn Fn(&CelVal, &CelVal) -> CelVal;
+
+pub type FunctionOp = dyn Fn(&[CelVal]) -> CelVal;

--- a/cel/src/common/functions.rs
+++ b/cel/src/common/functions.rs
@@ -1,4 +1,4 @@
-use crate::common::reference::CelVal;
+use crate::common::value::CelVal;
 
 pub type UnaryOp = dyn Fn(&CelVal) -> CelVal;
 

--- a/cel/src/common/mod.rs
+++ b/cel/src/common/mod.rs
@@ -1,4 +1,6 @@
 pub mod ast;
+pub mod decls;
+pub mod functions;
 pub mod traits;
 pub mod types;
 pub mod value;

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -1,0 +1,76 @@
+use crate::common::ast::Ast;
+use crate::common::functions::UnaryOp;
+use crate::common::types;
+use crate::common::types::Type;
+use crate::magic::IntoFunction;
+
+pub struct Env {}
+
+impl Env {
+    pub fn builder() -> EnvBuilder {
+        EnvBuilder::default()
+    }
+
+    pub fn parse(&self, text: &str) -> Result<Ast, ()> {
+        todo!("Implement this!")
+    }
+
+    pub fn check(&self, ast: Ast) -> Result<Ast, ()> {
+        Ok(ast)
+    }
+
+    pub fn compile(&self, text: &str) -> Result<Ast, ()> {
+        self.check(self.parse(text)?)
+    }
+}
+
+pub struct EnvBuilder {}
+
+impl EnvBuilder {
+    pub fn build(&self) -> Env {
+        Env {}
+    }
+
+    pub fn add_type(&mut self, t: Type) -> &mut Self {
+        self
+    }
+
+    pub fn add_variable(&mut self, binding: &str, t: Type) -> &mut Self {
+        self
+    }
+
+    pub fn add_overload<T: 'static, F>(
+        &mut self,
+        fn_name: &str,
+        overload_name: &str,
+        arg_types: &[&Type],
+        ret_type: &Type,
+        f: F
+    ) -> &mut Self
+    where
+        F: IntoFunction<T> + 'static + Send + Sync,
+    {
+        self
+    }
+    
+    pub fn add_member_overload<T: 'static, F>(
+        &mut self,
+        fn_name: &str,
+        overload_name: &str,
+        target_type: &Type,
+        arg_types: &[&Type],
+        ret_type: &Type,
+        f: F
+    ) -> &mut Self
+    where
+        F: IntoFunction<T> + 'static + Send + Sync,
+    {
+        self
+    }
+}
+
+impl Default for EnvBuilder {
+    fn default() -> Self {
+        Self {}
+    }
+}

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -1,3 +1,28 @@
+//! # Parser and Interpreter for the Common Expression Language (CEL)
+//!
+//! ## Usage example
+//!
+//! ```
+//! use cel::common::value::CelVal;
+//! let opaque_type = cel::common::types::Type::new_opaque_type("foo");
+//!
+//! let env = cel::Env::builder()
+//!     .add_type(opaque_type)
+//!     .add_variable("answer", cel::common::types::UINT_TYPE)
+//!     .add_overload("is_it", "is_it_uint", &[&cel::common::types::UINT_TYPE], &cel::common::types::BOOL_TYPE, is_it)
+//!     .add_member_overload("is_it", "is_it_on_uint", &cel::common::types::UINT_TYPE, &[], &cel::common::types::BOOL_TYPE, is_it)
+//!     .build();
+//!
+//! let mut ast = env.parse("(answer == 42) == is_it(answer) && answer.is_it()")?;
+//! ast = env.check(ast)?;
+//!
+//! //let prog = Program::new(ast);
+//!
+//! fn is_it(val: &CelVal) -> CelVal {
+//!      CelVal::Boolean(true)
+//! }
+//! ```
+
 extern crate core;
 
 use std::convert::TryFrom;
@@ -21,6 +46,13 @@ pub mod functions;
 mod magic;
 pub mod objects;
 mod resolvers;
+
+// NEW API
+mod env;
+pub use env::Env;
+pub use env::EnvBuilder;
+
+pub mod stdlib;
 
 #[cfg(feature = "chrono")]
 mod duration;

--- a/cel/src/stdlib/mod.rs
+++ b/cel/src/stdlib/mod.rs
@@ -1,0 +1,3 @@
+pub fn optional_syntax(enabled: bool) -> LibOption {
+    todo!()
+}


### PR DESCRIPTION
Starting this as a place to discuss how to slowly emerge an API that lets users easily configure an `Env`ironment to use in with their CEL expressions to parse, check and eventually evaluate them. 

see the current doc on the `lib.rs`

```rust
use cel::common::value::CelVal;
let opaque_type = cel::common::types::Type::new_opaque_type("foo");

let env = cel::Env::builder()
    .add_type(opaque_type)
    .add_variable("answer", cel::common::types::UINT_TYPE)
    .add_overload("is_it", "is_it_uint", &[&cel::common::types::UINT_TYPE], &cel::common::types::BOOL_TYPE, is_it)
    .add_member_overload("is_it", "is_it_on_uint", &cel::common::types::UINT_TYPE, &[], &cel::common::types::BOOL_TYPE, is_it)
    .build();

let mut ast = env.parse("(answer == 42) == is_it(answer) && answer.is_it()")?;
ast = env.check(ast)?;

//let prog = Program::new(ast);

fn is_it(val: &CelVal) -> CelVal {
     CelVal::Boolean(true)
}
```