### PR TITLE
cleanup: member shouldn't ever lookup for functions, does it?

### DIFF
--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -94,13 +94,6 @@ impl Context<'_> {
         }
     }
 
-    pub(crate) fn has_function(&self, name: &str) -> bool {
-        match self {
-            Context::Root { functions, .. } => functions.has(name),
-            Context::Child { parent, .. } => parent.has_function(name),
-        }
-    }
-
     pub(crate) fn get_function(&self, name: &str) -> Option<&Function> {
         match self {
             Context::Root { functions, .. } => functions.get(name),

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -233,6 +233,7 @@ mod tests {
 
         // Test methods
         assert_output("size([1, 2, 3]) == 3", Ok(true.into()));
+        assert_output("size([size([42]), 2, 3]) == 3", Ok(true.into()));
         assert_output("size([]) == 3", Ok(false.into()));
 
         // Test variable attribute traversals

--- a/cel/src/magic.rs
+++ b/cel/src/magic.rs
@@ -319,10 +319,6 @@ impl FunctionRegistry {
     pub(crate) fn get(&self, name: &str) -> Option<&Function> {
         self.functions.get(name)
     }
-
-    pub(crate) fn has(&self, name: &str) -> bool {
-        self.functions.contains_key(name)
-    }
 }
 
 pub type Function = Box<dyn Fn(&mut FunctionContext) -> ResolveResult + Send + Sync>;

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -704,7 +704,7 @@ impl Value {
                         _ => Ok(Value::Bool(false)),
                     }
                 } else {
-                    left.member(&select.field, ctx)
+                    left.member(&select.field)
                 }
             }
             Expr::List(list_expr) => {
@@ -777,7 +777,7 @@ impl Value {
     //               Attribute("b")),
     //        FunctionCall([Ident("c")]))
 
-    fn member(self, name: &str, ctx: &Context) -> ResolveResult {
+    fn member(self, name: &str) -> ResolveResult {
         // todo! Ideally we would avoid creating a String just to create a Key for lookup in the
         // map, but this would require something like the `hashbrown` crate's `Equivalent` trait.
         let name: Arc<String> = name.to_owned().into();
@@ -794,8 +794,6 @@ impl Value {
         // to see if the next token is a function call?
         if let Some(child) = child {
             child.into()
-        } else if ctx.has_function(&name) {
-            Value::Function(name.clone(), Some(self.into())).into()
         } else {
             ExecutionError::NoSuchKey(name.clone()).into()
         }


### PR DESCRIPTION
I could be wrong here... but this is probably a left over from the previous parser, am I missing something?