### PR TITLE
feat: Partially add Kubernetes list library

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -39,3 +39,5 @@ json = ["dep:serde_json", "dep:base64"]
 regex = ["dep:regex"]
 chrono = ["dep:chrono"]
 dhat-heap = [ ] # if you are doing heap profiling
+k8s = ["k8s-list"]
+k8s-list = [ ]

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -202,6 +202,16 @@ impl Default for Context<'_> {
         ctx.add_function("or", functions::optional_or_optional);
         ctx.add_function("orValue", functions::optional_or_value);
 
+        #[cfg(feature = "k8s-list")]
+        {
+            ctx.add_function("isSorted", functions::k8s::list::is_sorted);
+            // Skipping sum (Needs additional infrastructure: fallible add)
+            // Skipping max (Due to overloads)
+            // Skipping min (Due to overloads)
+            ctx.add_function("indexOf", functions::k8s::list::index_of);
+            ctx.add_function("lastIndexOf", functions::k8s::list::last_index_of);
+        }
+
         #[cfg(feature = "regex")]
         ctx.add_function("matches", functions::matches);
 

--- a/cel/src/functions/k8s/list.rs
+++ b/cel/src/functions/k8s/list.rs
@@ -65,3 +65,43 @@ fn find_position<'a>(
         None => Ok(-1i64),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::assert_script_eq;
+
+    #[test]
+    fn is_sorted() {
+        #[rustfmt::skip]
+        [
+            ("is not alphabetically sorted", "['c', 'a', 'b'].isSorted()", false.into()),
+            ("is alphabetically sorted", "['a', 'b', 'c'].isSorted()", true.into()),
+            ("is not numerically sorted", "[3, 1, 2].isSorted()", false.into()),
+            ("is numerically sorted", "[1, 2, 3].isSorted()", true.into()),
+        ]
+        .into_iter()
+        .for_each(assert_script_eq);
+    }
+
+    #[test]
+    fn index_of() {
+        #[rustfmt::skip]
+        [
+            ("index of a is 0", "['a', 'b', 'a'].indexOf('a')", 0.into()),
+            ("index of b is 0", "['a', 'b', 'a'].indexOf('b')", 1.into()),
+        ]
+        .into_iter()
+        .for_each(assert_script_eq);
+    }
+
+    #[test]
+    fn last_index_of() {
+        #[rustfmt::skip]
+        [
+            ("last index of a is 0", "['a', 'b', 'a'].lastIndexOf('a')", 0.into()),
+            ("last index of b is 1", "['a', 'b', 'a'].lastIndexOf('b')", 1.into()),
+        ]
+        .into_iter()
+        .for_each(assert_script_eq);
+    }
+}

--- a/cel/src/functions/k8s/list.rs
+++ b/cel/src/functions/k8s/list.rs
@@ -1,0 +1,67 @@
+//! Implements functions of the Kubernetes list library.
+//!
+//! See:
+//!
+//! - https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-list-library
+//! - https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/library#Lists
+
+use std::sync::Arc;
+
+use crate::{functions::Result, magic::This, FunctionContext, Value};
+
+/// Implements the `isSorted` function of the Kubernetes list library.
+///
+/// Returns whether the list is sorted and is supported on all comparable types.
+///
+/// See: https://github.com/kubernetes/apiextensions-apiserver/blob/ab2ddc498e31f2701200bff261e89120b3d929c3/pkg/apiserver/schema/cel/library/lists.go#L178
+pub fn is_sorted(This(this): This<Arc<Vec<Value>>>) -> bool {
+    this.is_sorted()
+}
+
+/// Implements the `indexOf` function of the Kubernetes list library.
+///
+/// Returns the first positional index of the provided element in the list.
+///
+/// See: https://github.com/kubernetes/apiextensions-apiserver/blob/ab2ddc498e31f2701200bff261e89120b3d929c3/pkg/apiserver/schema/cel/library/lists.go#L274
+pub fn index_of(
+    ftx: &FunctionContext,
+    This(this): This<Arc<Vec<Value>>>,
+    arg: Value,
+) -> Result<i64> {
+    find_position(ftx, this.iter(), &arg)
+}
+
+/// Implements the `lastIndexOf` function of the Kubernetes list library.
+///
+/// Returns the last positional index of the provided element in the list.
+///
+/// See: https://github.com/kubernetes/apiextensions-apiserver/blob/ab2ddc498e31f2701200bff261e89120b3d929c3/pkg/apiserver/schema/cel/library/lists.go#L288
+pub fn last_index_of(
+    ftx: &FunctionContext,
+    This(this): This<Arc<Vec<Value>>>,
+    arg: Value,
+) -> Result<i64> {
+    find_position(ftx, this.iter().rev(), &arg)
+}
+
+fn find_position<'a>(
+    ftx: &FunctionContext,
+    mut iter: impl Iterator<Item = &'a Value>,
+    needle: &Value,
+) -> Result<i64> {
+    // Find the position (index) based on the equality of the list element and
+    // the provided needle. This returns an Option, because the provided needle
+    // might not be present in the list.
+    let pos = iter.position(|element| element == needle);
+
+    // If the position/index could not be found, -1 is returned. This is done in
+    // accordance with the upstream Kubernetes implementation. See here:
+    // https://github.com/kubernetes/apiextensions-apiserver/blob/ab2ddc498e31f2701200bff261e89120b3d929c3/pkg/apiserver/schema/cel/library/lists.go#L285
+    // This further tries needs to convert the usize into a signed integer (i64)
+    // which can fail. If this is the case, an execution error is returned.
+    match pos {
+        Some(pos) => i64::try_from(pos)
+            .map_err(|err| ftx.error(format!("cannot convert usize into i64: {err}"))),
+        None => Ok(-1i64),
+    }
+}

--- a/cel/src/functions/k8s/mod.rs
+++ b/cel/src/functions/k8s/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "k8s-list")]
+pub mod list;

--- a/cel/src/functions/mod.rs
+++ b/cel/src/functions/mod.rs
@@ -10,6 +10,13 @@ use std::sync::Arc;
 
 type Result<T> = std::result::Result<T, ExecutionError>;
 
+pub mod k8s;
+
+#[cfg(feature = "chrono")]
+pub mod time;
+#[cfg(feature = "chrono")]
+pub use time::{duration, timestamp};
+
 /// `FunctionContext` is a context object passed to functions when they are called.
 ///
 /// It contains references to the target object (if the function is called as
@@ -312,154 +319,6 @@ pub fn matches(
     match regex::Regex::new(&regex) {
         Ok(re) => Ok(re.is_match(&this)),
         Err(err) => Err(ftx.error(format!("'{regex}' not a valid regex:\n{err}"))),
-    }
-}
-
-#[cfg(feature = "chrono")]
-pub use time::duration;
-#[cfg(feature = "chrono")]
-pub use time::timestamp;
-
-#[cfg(feature = "chrono")]
-pub mod time {
-    use super::Result;
-    use crate::magic::This;
-    use crate::{ExecutionError, Value};
-    use chrono::{Datelike, Days, Months, Timelike};
-    use std::sync::Arc;
-
-    /// Duration parses the provided argument into a [`Value::Duration`] value.
-    ///
-    /// The argument must be string, and must be in the format of a duration. See
-    /// the [`parse_duration`] documentation for more information on the supported
-    /// formats.
-    ///
-    /// # Examples
-    /// - `1h` parses as 1 hour
-    /// - `1.5h` parses as 1 hour and 30 minutes
-    /// - `1h30m` parses as 1 hour and 30 minutes
-    /// - `1h30m1s` parses as 1 hour, 30 minutes, and 1 second
-    /// - `1ms` parses as 1 millisecond
-    /// - `1.5ms` parses as 1 millisecond and 500 microseconds
-    /// - `1ns` parses as 1 nanosecond
-    /// - `1.5ns` parses as 1 nanosecond (sub-nanosecond durations not supported)
-    pub fn duration(value: Arc<String>) -> crate::functions::Result<Value> {
-        Ok(Value::Duration(_duration(value.as_str())?))
-    }
-
-    /// Timestamp parses the provided argument into a [`Value::Timestamp`] value.
-    /// The
-    pub fn timestamp(value: Arc<String>) -> Result<Value> {
-        Ok(Value::Timestamp(
-            chrono::DateTime::parse_from_rfc3339(value.as_str())
-                .map_err(|e| ExecutionError::function_error("timestamp", e.to_string().as_str()))?,
-        ))
-    }
-
-    /// A wrapper around [`parse_duration`] that converts errors into [`ExecutionError`].
-    /// and only returns the duration, rather than returning the remaining input.
-    fn _duration(i: &str) -> Result<chrono::Duration> {
-        let (_, duration) = crate::duration::parse_duration(i)
-            .map_err(|e| ExecutionError::function_error("duration", e.to_string()))?;
-        Ok(duration)
-    }
-
-    fn _timestamp(i: &str) -> Result<chrono::DateTime<chrono::FixedOffset>> {
-        chrono::DateTime::parse_from_rfc3339(i)
-            .map_err(|e| ExecutionError::function_error("timestamp", e.to_string()))
-    }
-
-    pub fn timestamp_year(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok(this.year().into())
-    }
-
-    pub fn timestamp_month(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok((this.month0() as i32).into())
-    }
-
-    pub fn timestamp_year_day(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        let year = this
-            .checked_sub_days(Days::new(this.day0() as u64))
-            .unwrap()
-            .checked_sub_months(Months::new(this.month0()))
-            .unwrap();
-        Ok(this.signed_duration_since(year).num_days().into())
-    }
-
-    pub fn timestamp_month_day(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok((this.day0() as i32).into())
-    }
-
-    pub fn timestamp_date(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok((this.day() as i32).into())
-    }
-
-    pub fn timestamp_weekday(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok((this.weekday().num_days_from_sunday() as i32).into())
-    }
-
-    pub fn get_hours(This(this): This<Value>) -> Result<Value> {
-        Ok(match this {
-            Value::Timestamp(ts) => (ts.hour() as i32).into(),
-            Value::Duration(d) => (d.num_hours() as i32).into(),
-            _ => {
-                return Err(ExecutionError::function_error(
-                    "getHours",
-                    "expected timestamp or duration",
-                ))
-            }
-        })
-    }
-
-    pub fn get_minutes(This(this): This<Value>) -> Result<Value> {
-        Ok(match this {
-            Value::Timestamp(ts) => (ts.minute() as i32).into(),
-            Value::Duration(d) => (d.num_minutes() as i32).into(),
-            _ => {
-                return Err(ExecutionError::function_error(
-                    "getMinutes",
-                    "expected timestamp or duration",
-                ))
-            }
-        })
-    }
-
-    pub fn get_seconds(This(this): This<Value>) -> Result<Value> {
-        Ok(match this {
-            Value::Timestamp(ts) => (ts.second() as i32).into(),
-            Value::Duration(d) => (d.num_seconds() as i32).into(),
-            _ => {
-                return Err(ExecutionError::function_error(
-                    "getSeconds",
-                    "expected timestamp or duration",
-                ))
-            }
-        })
-    }
-
-    pub fn get_milliseconds(This(this): This<Value>) -> Result<Value> {
-        Ok(match this {
-            Value::Timestamp(ts) => (ts.timestamp_subsec_millis() as i32).into(),
-            Value::Duration(d) => (d.num_milliseconds() as i32).into(),
-            _ => {
-                return Err(ExecutionError::function_error(
-                    "getMilliseconds",
-                    "expected timestamp or duration",
-                ))
-            }
-        })
     }
 }
 

--- a/cel/src/functions/mod.rs
+++ b/cel/src/functions/mod.rs
@@ -372,23 +372,10 @@ pub fn min(Arguments(args): Arguments) -> Result<Value> {
 
 #[cfg(test)]
 mod tests {
-    use crate::context::Context;
-    use crate::tests::test_script;
-
-    fn assert_script(input: &(&str, &str)) {
-        assert_eq!(test_script(input.1, None), Ok(true.into()), "{}", input.0);
-    }
-
-    fn assert_error(input: &(&str, &str, &str)) {
-        assert_eq!(
-            test_script(input.1, None)
-                .expect_err("expected error")
-                .to_string(),
-            input.2,
-            "{}",
-            input.0
-        );
-    }
+    use crate::{
+        context::Context,
+        test_utils::{assert_error, assert_script, test_script},
+    };
 
     #[test]
     fn test_size() {
@@ -400,7 +387,7 @@ mod tests {
             ("size as a list method", "[1, 2, 3].size() == 3"),
             ("size as a string method", "'foobar'.size() == 6"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -436,14 +423,14 @@ mod tests {
                 r#"{'John': 'smart'}.map(key, key) == ['John']"#,
             ),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
     #[test]
     fn test_filter() {
         [("filter list", "[1, 2, 3].filter(x, x > 2) == [3]")]
-            .iter()
+            .into_iter()
             .for_each(assert_script);
     }
 
@@ -454,7 +441,7 @@ mod tests {
             ("all list #2", "[0, 1, 2].all(x, x > 0) == false"),
             ("all map", "{0: 0, 1:1, 2:2}.all(x, x >= 0) == true"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -466,7 +453,7 @@ mod tests {
             ("exist list #3", "[0, 1, 2, 2].exists(x, x == 2)"),
             ("exist map", "{0: 0, 1:1, 2:2}.exists(x, x > 0)"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -477,7 +464,7 @@ mod tests {
             ("exist list #2", "[0, 1, 2].exists_one(x, x == 0)"),
             ("exist map", "{0: 0, 1:1, 2:2}.exists_one(x, x == 2)"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -492,7 +479,7 @@ mod tests {
             ("max empty list", "max([]) == null"),
             ("max no args", "max() == null"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -511,7 +498,7 @@ mod tests {
             ("min empty list", "min([]) == null"),
             ("min no args", "min() == null"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -521,7 +508,7 @@ mod tests {
             ("starts with true", "'foobar'.startsWith('foo') == true"),
             ("starts with false", "'foobar'.startsWith('bar') == false"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -531,7 +518,7 @@ mod tests {
             ("ends with true", "'foobar'.endsWith('bar') == true"),
             ("ends with false", "'foobar'.endsWith('foo') == false"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -603,7 +590,7 @@ mod tests {
                 "timestamp('2023-05-28T00:00:42.123Z').getMilliseconds() == 123",
             ),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
 
         [
@@ -633,7 +620,7 @@ mod tests {
                 "Overflow from binary operator 'add': Timestamp(0001-01-01T00:00:00+00:00), Duration(TimeDelta { secs: -1, nanos: 0 })",
             ),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_error)
     }
 
@@ -680,7 +667,7 @@ mod tests {
                 "duration('90s').getSeconds() == 90",
             ),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -709,7 +696,7 @@ mod tests {
                 "timestamp('2023-05-29T00:00:00Z').string() == '2023-05-29T00:00:00+00:00'",
             ),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -770,7 +757,7 @@ mod tests {
             ("float", "10.5.string() == '10.5'"),
             ("bytes", "b'foo'.string() == 'foo'"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -780,7 +767,7 @@ mod tests {
             ("string", "bytes('abc') == b'abc'"),
             ("bytes", "bytes('abc') == b'\\x61b\\x63'"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -791,7 +778,7 @@ mod tests {
             ("int", "10.double() == 10.0"),
             ("double", "10.0.double() == 10.0"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -801,7 +788,7 @@ mod tests {
             ("string", "'10'.uint() == 10.uint()"),
             ("double", "10.5.uint() == 10.uint()"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -813,7 +800,7 @@ mod tests {
             ("uint", "10.uint().int() == 10"),
             ("double", "10.5.int() == 10"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_script);
     }
 
@@ -828,7 +815,7 @@ mod tests {
             ("map || bool", "{} || false", "No such overload"),
             ("null || bool", "null || false", "No such overload"),
         ]
-        .iter()
+        .into_iter()
         .for_each(assert_error)
     }
 }

--- a/cel/src/functions/time.rs
+++ b/cel/src/functions/time.rs
@@ -1,0 +1,131 @@
+use super::Result;
+use crate::magic::This;
+use crate::{ExecutionError, Value};
+use chrono::{Datelike, Days, Months, Timelike};
+use std::sync::Arc;
+
+/// Duration parses the provided argument into a [`Value::Duration`] value.
+///
+/// The argument must be string, and must be in the format of a duration. See
+/// the [`parse_duration`] documentation for more information on the supported
+/// formats.
+///
+/// # Examples
+/// - `1h` parses as 1 hour
+/// - `1.5h` parses as 1 hour and 30 minutes
+/// - `1h30m` parses as 1 hour and 30 minutes
+/// - `1h30m1s` parses as 1 hour, 30 minutes, and 1 second
+/// - `1ms` parses as 1 millisecond
+/// - `1.5ms` parses as 1 millisecond and 500 microseconds
+/// - `1ns` parses as 1 nanosecond
+/// - `1.5ns` parses as 1 nanosecond (sub-nanosecond durations not supported)
+pub fn duration(value: Arc<String>) -> crate::functions::Result<Value> {
+    Ok(Value::Duration(_duration(value.as_str())?))
+}
+
+/// Timestamp parses the provided argument into a [`Value::Timestamp`] value.
+/// The
+pub fn timestamp(value: Arc<String>) -> Result<Value> {
+    Ok(Value::Timestamp(
+        chrono::DateTime::parse_from_rfc3339(value.as_str())
+            .map_err(|e| ExecutionError::function_error("timestamp", e.to_string().as_str()))?,
+    ))
+}
+
+/// A wrapper around [`parse_duration`] that converts errors into [`ExecutionError`].
+/// and only returns the duration, rather than returning the remaining input.
+fn _duration(i: &str) -> Result<chrono::Duration> {
+    let (_, duration) = crate::duration::parse_duration(i)
+        .map_err(|e| ExecutionError::function_error("duration", e.to_string()))?;
+    Ok(duration)
+}
+
+fn _timestamp(i: &str) -> Result<chrono::DateTime<chrono::FixedOffset>> {
+    chrono::DateTime::parse_from_rfc3339(i)
+        .map_err(|e| ExecutionError::function_error("timestamp", e.to_string()))
+}
+
+pub fn timestamp_year(This(this): This<chrono::DateTime<chrono::FixedOffset>>) -> Result<Value> {
+    Ok(this.year().into())
+}
+
+pub fn timestamp_month(This(this): This<chrono::DateTime<chrono::FixedOffset>>) -> Result<Value> {
+    Ok((this.month0() as i32).into())
+}
+
+pub fn timestamp_year_day(
+    This(this): This<chrono::DateTime<chrono::FixedOffset>>,
+) -> Result<Value> {
+    let year = this
+        .checked_sub_days(Days::new(this.day0() as u64))
+        .unwrap()
+        .checked_sub_months(Months::new(this.month0()))
+        .unwrap();
+    Ok(this.signed_duration_since(year).num_days().into())
+}
+
+pub fn timestamp_month_day(
+    This(this): This<chrono::DateTime<chrono::FixedOffset>>,
+) -> Result<Value> {
+    Ok((this.day0() as i32).into())
+}
+
+pub fn timestamp_date(This(this): This<chrono::DateTime<chrono::FixedOffset>>) -> Result<Value> {
+    Ok((this.day() as i32).into())
+}
+
+pub fn timestamp_weekday(This(this): This<chrono::DateTime<chrono::FixedOffset>>) -> Result<Value> {
+    Ok((this.weekday().num_days_from_sunday() as i32).into())
+}
+
+pub fn get_hours(This(this): This<Value>) -> Result<Value> {
+    Ok(match this {
+        Value::Timestamp(ts) => (ts.hour() as i32).into(),
+        Value::Duration(d) => (d.num_hours() as i32).into(),
+        _ => {
+            return Err(ExecutionError::function_error(
+                "getHours",
+                "expected timestamp or duration",
+            ))
+        }
+    })
+}
+
+pub fn get_minutes(This(this): This<Value>) -> Result<Value> {
+    Ok(match this {
+        Value::Timestamp(ts) => (ts.minute() as i32).into(),
+        Value::Duration(d) => (d.num_minutes() as i32).into(),
+        _ => {
+            return Err(ExecutionError::function_error(
+                "getMinutes",
+                "expected timestamp or duration",
+            ))
+        }
+    })
+}
+
+pub fn get_seconds(This(this): This<Value>) -> Result<Value> {
+    Ok(match this {
+        Value::Timestamp(ts) => (ts.second() as i32).into(),
+        Value::Duration(d) => (d.num_seconds() as i32).into(),
+        _ => {
+            return Err(ExecutionError::function_error(
+                "getSeconds",
+                "expected timestamp or duration",
+            ))
+        }
+    })
+}
+
+pub fn get_milliseconds(This(this): This<Value>) -> Result<Value> {
+    Ok(match this {
+        Value::Timestamp(ts) => (ts.timestamp_subsec_millis() as i32).into(),
+        Value::Duration(d) => (d.num_milliseconds() as i32).into(),
+        _ => {
+            return Err(ExecutionError::function_error(
+                "getMilliseconds",
+                "expected timestamp or duration",
+            ))
+        }
+    })
+}

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use thiserror::Error;
 
 mod macros;
+#[cfg(test)]
+mod test_utils;
 
 pub mod common;
 pub mod context;
@@ -205,18 +207,10 @@ impl TryFrom<&str> for Program {
 mod tests {
     use crate::context::Context;
     use crate::objects::{ResolveResult, Value};
+    use crate::test_utils::test_script;
     use crate::{ExecutionError, Program};
     use std::collections::HashMap;
     use std::convert::TryInto;
-
-    /// Tests the provided script and returns the result. An optional context can be provided.
-    pub(crate) fn test_script(script: &str, ctx: Option<Context>) -> ResolveResult {
-        let program = match Program::compile(script) {
-            Ok(p) => p,
-            Err(e) => panic!("{}", e),
-        };
-        program.execute(&ctx.unwrap_or_default())
-    }
 
     #[test]
     fn parse() {

--- a/cel/src/test_utils.rs
+++ b/cel/src/test_utils.rs
@@ -1,0 +1,32 @@
+use crate::{Context, Program, ResolveResult, Value};
+
+/// Tests the provided script and returns the result. An optional context can be provided.
+pub(crate) fn test_script(script: &str, ctx: Option<Context>) -> ResolveResult {
+    let program = match Program::compile(script) {
+        Ok(program) => program,
+        Err(err) => panic!("{err}"),
+    };
+    program.execute(&ctx.unwrap_or_default())
+}
+
+/// Asserts that the provided script evaluates to `true`.
+pub(crate) fn assert_script(input: (&str, &str)) {
+    let (description, script) = input;
+    assert_eq!(test_script(script, None), Ok(true.into()), "{description}");
+}
+
+/// Asserts that the provided script evaluates and returns `expected`.
+pub(crate) fn assert_script_eq(input: (&str, &str, Value)) {
+    let (description, script, expected) = input;
+    assert_eq!(test_script(script, None), Ok(expected), "{description}");
+}
+
+/// Asserts that the provided script returns an error and that the error matches
+/// the provided message.
+pub(crate) fn assert_error(input: (&str, &str, &str)) {
+    let (description, script, expected_error_message) = input;
+    let error_message = test_script(script, None)
+        .expect_err("expected error")
+        .to_string();
+    assert_eq!(error_message, expected_error_message, "{description}",);
+}


### PR DESCRIPTION
This PR adds the `isSorted`, `indexOf`, and `lastIndeOf` functions of the [Kubernetes list library](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-list-library). The `sum`, `max`, and `min` functions are missing because of the following two reasons:

- For `sum`, we need additional infrastructure for "addable" types which might need to support fallibility.
- Both `max` and `min` are already registered functions and as far as I understood this then needs overloads, right?

A few notes for reviewers:

- I moved testing utilities into their own file. These functions are still gated with `#[cfg(test)]` of course.
- I adjusted the module layout for all the provided functions. All time/chrono related functions just got moved, but Git shows that as deletions and additions.
- I added two new features: `k8s` and `k8s-list`, with the former including the latter.

---

I'm also working on additional PRs which will add the Kubernetes regex, URL, and SemVer libraries. I might also work on others like the IP address and CIDR ones. I will raise these PRs in the next coming days.