### PR TITLE
Experiment: no copy

### DIFF
--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -233,8 +233,8 @@ impl<'a> Type<'a> {
     }
 }
 
-fn leak_ref<'a, T: ?Sized>(s: *const T) -> &'a T {
-    unsafe { &*s }
+unsafe fn leak_ref<'a, T: ?Sized>(s: *const T) -> &'a T {
+    &*s
 }
 
 /// Try to cast a `Box<dyn Val>` to its concrete type `T: Val`

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -233,6 +233,10 @@ impl<'a> Type<'a> {
     }
 }
 
+fn leak_ref<'a, T: ?Sized>(s: *const T) -> &'a T {
+    unsafe { &*s }
+}
+
 /// Try to cast a `Box<dyn Val>` to its concrete type `T: Val`
 /// Will return `Result::Ok` if the type check succeeded with the actual Box to the
 /// `Box<T>`. `Result::Err` with the `Box<dyn Val>` back to the caller should the type check

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -233,22 +233,97 @@ impl<'a> Type<'a> {
     }
 }
 
+/// Extends the lifetime of a `*const T` into a caller-chosen `&'a T`.
+///
+/// Lifetime-laundry primitive: the caller picks `'a`, which may be much
+/// longer than any borrow the raw pointer was derived from (including
+/// `'static`). Use only when a documented project-local invariant bounds
+/// every read of the returned reference to the real liveness of the
+/// pointee; the caller's SAFETY comment must name that invariant. The
+/// only current user is `<BorrowedVal<'a, String> as From<&'a str>>` in
+/// `string.rs`, relying on the Safety invariant on `String`'s field and
+/// on `BorrowedVal::phantom`. Prefer safe borrow-based APIs whenever
+/// possible.
+///
+/// # Safety
+///
+/// The caller must ensure that, for the entire caller-chosen lifetime
+/// `'a`:
+///
+/// 1. `s` is non-null.
+/// 2. `s` is properly aligned for `T`.
+/// 3. `s` carries correct metadata for `T` (e.g. the length for `str`
+///    and slices), and the whole `size_of_val` byte range starting at
+///    `s` lies in one live allocation and holds a valid, initialized
+///    `T`.
+/// 4. The allocation backing `s` remains live: no deallocation,
+///    reallocation, or repurposing occurs.
+/// 5. No other access path mutates the pointee (except through
+///    `UnsafeCell` inside `T`), and no `&mut` reference to the pointee
+///    is alive.
+///
+/// The chosen `'a` is not tied to any source borrow by the compiler.
+/// Callers must audit every downstream use site, including drops, to
+/// confirm the returned reference is neither read nor dropped as part of
+/// a value after the duration for which conditions 1–5 hold.
+///
+/// If these preconditions hold, the returned `&'a T` is a valid shared
+/// reference to the pointee for all of `'a`.
 unsafe fn leak_ref<'a, T: ?Sized>(s: *const T) -> &'a T {
+    // SAFETY:
+    // Operation: creating a shared reference from a raw pointer via `&*s`.
+    // Contract (AXIOM: Rust Reference, reference validity and place
+    // expressions): `s` must be dereferenceable, i.e. non-null, aligned
+    // for `T`, with correct metadata and its full `size_of_val` range in
+    // one live allocation; the pointee must be a valid initialized `T`;
+    // and no conflicting `&mut` alias may exist for the reference's
+    // lifetime `'a`.
+    // Evidence: each of these obligations is exactly one of
+    // PRECONDITIONS 1–5 in this function's `# Safety` section, which the
+    // caller has discharged. Nothing in this body mutates state or runs
+    // intervening code that could invalidate them.
     &*s
 }
 
-/// Try to cast a `Box<dyn Val>` to its concrete type `T: Val`
-/// Will return `Result::Ok` if the type check succeeded with the actual Box to the
-/// `Box<T>`. `Result::Err` with the `Box<dyn Val>` back to the caller should the type check
-/// fail.
+/// Try to cast a `Box<dyn Val>` to its concrete type `T: Val`.
+///
+/// Returns `Ok(Box<T>)` if the underlying concrete type is exactly `T`,
+/// otherwise returns `Err(Box<dyn Val>)` with the original box unchanged.
 fn cast_boxed<T: Val>(value: Box<dyn Val>) -> Result<Box<T>, Box<dyn Val>> {
     if <dyn Any>::is::<T>(&*value) {
-        let temp_container = &mut Some(value);
-        // SAFETY: just checked whether we are pointing to the correct type, and we can rely on
-        // that check for memory safety because we have implemented Any for all types; no other
-        // impls can exist as they would conflict with our impl.
-        let temp_container = unsafe { &mut *(temp_container as *mut _ as *mut Option<Box<T>>) };
-        return Ok(temp_container.take().unwrap());
+        // Mirror std's `Box<dyn Any>::downcast` pattern: consume the
+        // source `Box` via `Box::into_raw`, thin the resulting fat
+        // pointer to `*mut T`, and reconstitute a `Box<T>`.
+        let raw: *mut dyn Val = Box::into_raw(value);
+        // SAFETY:
+        // Operation: `Box::from_raw(raw as *mut T)`.
+        // Contract from `Box::from_raw` (AXIOM: std docs): the pointer
+        // must have been produced by a prior `Box::into_raw` for a value
+        // whose concrete type has the same layout and alignment as `T`,
+        // and be usable with the global allocator; the resulting `Box`
+        // takes exclusive ownership and will free the allocation with
+        // `T`'s layout on drop.
+        // Evidence:
+        //   - POSTCONDITION of `Box::into_raw(value)` (AXIOM: std docs):
+        //     `raw` points to the heap allocation that `value` owned,
+        //     ownership has been surrendered, and no other Box currently
+        //     owns the allocation.
+        //   - `T: Val` (TYPE FACT) and `Val: Any` (declared on the trait
+        //     in `common::value::Val`), so `<dyn Any>::is::<T>(&*value)`
+        //     called above compares `TypeId::of::<T>()` against the
+        //     concrete type behind the trait object. When it returns
+        //     true, AXIOM (std docs for `Any::is`) states that the
+        //     concrete type is exactly `T`.
+        //   - Therefore the heap allocation was constructed for `T` and
+        //     has `T`'s layout and alignment; `raw as *mut T` is a
+        //     non-null pointer to an aligned, initialized `T` in that
+        //     allocation.
+        //   - Between the type-id check and this `Box::from_raw`, no
+        //     code observes, aliases, or frees the allocation.
+        // Postcondition: the returned `Box<T>` is the unique owner of
+        // the heap allocation and will free it with `T`'s layout on
+        // drop.
+        return Ok(unsafe { Box::from_raw(raw as *mut T) });
     }
     Err(value)
 }

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -7,16 +7,22 @@ use std::cmp::Ordering;
 use std::ops::Deref;
 use std::string::String as StdString;
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct String(Cow<'static, str>);
 
 impl String {
     pub fn into_inner(self) -> StdString {
-        self.0.clone().into()
+        self.clone().into()
     }
 
     pub fn inner(&self) -> &str {
         self.0.as_ref()
+    }
+}
+
+impl Clone for String {
+    fn clone(&self) -> Self {
+        Self(Cow::Owned(StdString::from(self.inner())))
     }
 }
 
@@ -152,5 +158,18 @@ mod tests {
         assert_eq!(string.as_str(), r.inner());
         assert!(std::ptr::eq(string.as_str(), r.inner()));
         assert!(std::ptr::eq(string.as_str(), r.inner()));
+    }
+
+    #[test]
+    fn test_clone() {
+        let s = {
+            let string = StdString::from("cel-rust");
+            let val = {
+                let s = string.as_ref();
+                BorrowedVal::from(s)
+            };
+            val.inner().clone()
+        };
+        assert_eq!(s, String::from("cel-rust"));
     }
 }

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -8,7 +8,27 @@ use std::ops::Deref;
 use std::string::String as StdString;
 
 #[derive(Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct String(Cow<'static, str>);
+pub struct String(
+    // Safety invariant: the `'static` on this `Cow` may be a lie. The only
+    // constructor that stores the `Borrowed` variant is
+    // `<BorrowedVal<'a, String> as From<&'a str>>` in this file, which
+    // launders an `&'a str` to `&'static str` via `leak_ref`. Such a
+    // value is sound to read only while the enclosing
+    // `BorrowedVal<'a, String>` is alive, i.e. for `'a`.
+    //
+    // Consequently, no code may move or copy the `Borrowed` variant out
+    // of a `&String` into a value that is not itself bounded by `'a`.
+    // Every function that produces an owned `String`, `Box<dyn Val>`,
+    // `StdString`, or `Cow<'static, str>` from `&self` must go through
+    // `Cow::Owned` (see `Clone`, `Val::clone_as_boxed`, and
+    // `into_inner` in this file). Returning `&str` bounded by `&self`
+    // is fine. Adding a new such producer without re-auditing this
+    // invariant reintroduces a use-after-free reachable from safe code.
+    //
+    // Non-laundered values are always `Cow::Owned`; every other
+    // constructor in this file allocates.
+    Cow<'static, str>,
+);
 
 impl String {
     pub fn into_inner(self) -> StdString {
@@ -21,8 +41,8 @@ impl String {
 }
 
 impl Clone for String {
-    // SAFETY: this explicitly allocates a new `String` with the same contents as the original on the heap
-    // as we can't _ever_ reuse the `&'static str`, or the `Cow::Borrowed`.
+    // Upholds the Safety invariant on the field: the clone is always
+    // `Cow::Owned`, never a copy of a (possibly laundered) `Borrowed`.
     fn clone(&self) -> Self {
         Self(Cow::Owned(StdString::from(self.inner())))
     }
@@ -56,7 +76,11 @@ impl Val for String {
     }
 
     fn clone_as_boxed(&self) -> Box<dyn Val> {
-        Box::new(String(self.0.clone()))
+        // Upholds the Safety invariant on the field: `Box<dyn Val>` is
+        // `'static`, so the boxed value must not carry a laundered
+        // `Borrowed`. `self.clone()` always produces `Cow::Owned`.
+        // `String(self.0.clone())` would copy the `Borrowed` pointer.
+        Box::new(self.clone())
     }
 }
 
@@ -125,9 +149,43 @@ impl<'a> TryFrom<&'a dyn Val> for &'a str {
 
 impl<'a> From<&'a str> for BorrowedVal<'a, String> {
     fn from(value: &'a str) -> Self {
-        // SAFETY: BorrowedVal is retying the `'a` lifetime from the `&'a str`
-        // now, the `String`'s borrowed `leaked' reference also need to _never_
-        // escape the `String` by other means neither!
+        // SAFETY:
+        // Operation: `super::leak_ref::<'static, str>(value)`, the sole
+        // unsafe call in this block. `BorrowedVal::new` is a safe fn.
+        // Contract: `leak_ref`'s five `# Safety` preconditions must hold
+        // for the caller-chosen lifetime, here `'static`. Because the
+        // chosen lifetime exceeds the real one, `leak_ref`'s docs require
+        // a named project-local invariant that bounds every use of the
+        // returned reference. That invariant is the Safety invariant on
+        // the `Cow<'static, str>` field of `String` in this file, plus
+        // the Safety invariant on `BorrowedVal::phantom` in
+        // `common::value.rs`.
+        // Evidence:
+        //   1–3. AXIOM (Rust Reference, reference validity): a live
+        //        `&'a str` is non-null, aligned, and covers `len` bytes
+        //        of initialized UTF-8 in one live allocation, with
+        //        correct length metadata. The raw pointer decayed from
+        //        `value` therefore satisfies (1), (2), and (3) for `'a`.
+        //   4–5. TYPE FACT: `value: &'a str`, so the allocation is live
+        //        and no `&mut` alias exists for all of `'a`. The leaked
+        //        reference is only ever read within `'a` because:
+        //        - INVARIANT (`BorrowedVal::phantom`): the returned
+        //          `BorrowedVal<'a, String>` is bounded by `'a`, and its
+        //          explicit `Drop` impl makes the borrow checker require
+        //          `'a` to be live through the drop as well, so the
+        //          `Box<String>` inside is dropped before `'a` ends.
+        //        - INVARIANT (`String` field): every path from `&String`
+        //          to an owned value goes through `Cow::Owned`, so the
+        //          laundered `Borrowed` cannot be copied into a value
+        //          that outlives the `BorrowedVal`. The only reads of
+        //          the pointer are through `&str`s bounded by a borrow
+        //          of the `BorrowedVal`, hence by `'a`.
+        //        Therefore (4) and (5) hold at every read of the leaked
+        //        reference, and no read or drop occurs after `'a`.
+        // Postcondition: the returned `BorrowedVal<'a, String>` behaves
+        // as a borrow of `value`; every `&str` reachable through it has
+        // lifetime `<= 'a`, and every owned value derived from it copies
+        // the bytes.
         unsafe {
             let leaked: &'static str = super::leak_ref(value);
             let val = String(Cow::Borrowed(leaked));
@@ -165,6 +223,23 @@ mod tests {
         assert_eq!(string.as_str(), r.inner());
         assert!(std::ptr::eq(string.as_str(), r.inner()));
         assert!(std::ptr::eq(string.as_str(), r.inner()));
+    }
+
+    /// Regression: `clone_as_boxed` (and therefore `Cow::<dyn Val>::
+    /// into_owned`) must copy the bytes out of a laundered `Borrowed`,
+    /// never the pointer. Run under Miri to catch a use-after-free.
+    #[test]
+    fn test_clone_as_boxed_outlives_borrow() {
+        let (boxed, owned): (Box<dyn Val>, Box<dyn Val>) = {
+            let string = StdString::from("cel-rust");
+            let val = BorrowedVal::from(string.as_str());
+            let cow: std::borrow::Cow<dyn Val> = std::borrow::Cow::Borrowed(val.inner());
+            (val.inner().clone_as_boxed(), cow.into_owned())
+        };
+        let boxed = boxed.downcast_ref::<String>().unwrap();
+        let owned = owned.downcast_ref::<String>().unwrap();
+        assert_eq!(boxed.inner(), "cel-rust");
+        assert_eq!(owned.inner(), "cel-rust");
     }
 
     #[test]

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -4,6 +4,7 @@ use crate::common::traits::{
 use crate::common::types::Type;
 use std::any::Any;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 pub trait Val: Any + Debug + Send + Sync {
     fn get_type(&self) -> Type<'_>;
@@ -76,6 +77,24 @@ impl ToOwned for dyn Val {
 impl PartialEq for dyn Val {
     fn eq(&self, other: &Self) -> bool {
         self.equals(other)
+    }
+}
+
+pub struct BorrowedVal<'a, T: Val> {
+    val: Box<T>,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl<'a, T: Val> BorrowedVal<'a, T> {
+    pub fn new(val: T) -> Self {
+        Self {
+            val: Box::new(val),
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn inner(&self) -> &T {
+        self.val.as_ref()
     }
 }
 

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -80,9 +80,54 @@ impl PartialEq for dyn Val {
     }
 }
 
+/// A `T: Val` that borrows data for `'a`, even though `T` itself carries
+/// no lifetime.
+///
+/// The value cannot outlive `'a`, and because of its `Drop` impl it
+/// cannot even be *dropped* after `'a` ends:
+///
+/// ```compile_fail,E0597
+/// use cel::common::types::CelString;
+/// use cel::common::value::BorrowedVal;
+///
+/// let bv: BorrowedVal<'_, CelString>;
+/// {
+///     let s = String::from("bar");
+///     bv = BorrowedVal::from(s.as_str());
+/// } // error[E0597]: `s` does not live long enough (bv dropped later)
+/// ```
 pub struct BorrowedVal<'a, T: Val> {
     val: Box<T>,
+    // Safety invariant: this field is load-bearing. `Box<T>` does not
+    // itself mention `'a`, so without this `PhantomData` the compiler
+    // would not bound `BorrowedVal<'a, T>` by `'a`. That bound is what
+    // keeps every borrow reachable through the value, including a
+    // lifetime-laundered interior `&'static` produced inside `T` (see
+    // `<BorrowedVal<'a, String> as From<&'a str>>` in
+    // `common::types::string.rs`), bounded at `<= 'a` and prevented from
+    // outliving the borrow this wrapper represents. Do not remove this
+    // field, and do not weaken its variance (e.g. to `PhantomData<fn()
+    // -> &'a ()>` for contravariance, or `PhantomData<*const &'a ()>`
+    // for invariance without a borrow) without re-auditing every unsafe
+    // `From` / constructor that produces a `BorrowedVal`.
+    //
+    // The `PhantomData` alone does not make drop-check require `'a` to
+    // be live when the `BorrowedVal` is dropped; the explicit `Drop`
+    // impl below does. Do not remove that impl either: without it a
+    // `BorrowedVal` can be dropped after its referent is freed, and the
+    // drop glue of `T` then runs over a dangling laundered reference.
     phantom: PhantomData<&'a ()>,
+}
+
+// This impl exists solely for drop-check. A type with a `Drop` impl is
+// considered to access every lifetime in its type when dropped, so the
+// borrow checker requires `'a` to be live at the drop of a
+// `BorrowedVal<'a, T>`. That guarantees the inner `Box<T>` (and any
+// laundered `&'a` it holds, see the Safety invariant on `phantom`) is
+// dropped before the referent it borrows. The `compile_fail` doctest on
+// `BorrowedVal` pins this behaviour.
+impl<'a, T: Val> Drop for BorrowedVal<'a, T> {
+    fn drop(&mut self) {}
 }
 
 impl<'a, T: Val> BorrowedVal<'a, T> {

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -65,3 +65,7 @@ required-features = ["json"]
 name = "example-anyhow"
 path = "src/anyhow.rs"
 required-features = ["anyhow"]
+
+[[bin]]
+name = "example-var-resolver"
+path = "src/resolver.rs"

--- a/example/src/resolver.rs
+++ b/example/src/resolver.rs
@@ -36,16 +36,14 @@ fn main() {
     };
     context.set_variable_resolver(&resolver);
     let value = Value::resolve_val(&ast, &context).unwrap();
+    let value = value.downcast_ref::<CelString>().unwrap();
 
     // This should always pass
-    assert_eq!(
-        value.as_ref().downcast_ref::<CelString>(),
-        Some(&CelString::from("bar"))
-    );
+    assert_eq!(value, &CelString::from("bar"));
 
-    // But with when `foo != 'bar'`, we return a new CelString `"bar"`, the one borrowed from the AST
-    assert!(std::ptr::eq(
-        resolver.some_ref,
-        value.as_ref().downcast_ref::<CelString>().unwrap().inner()
-    ))
+    // But with `foo != 'bar'`, we return a different `"bar"` value, borrowed from the AST
+    assert!(
+        std::ptr::eq(resolver.some_ref, value.inner()),
+        "We want the same pointer here!"
+    )
 }

--- a/example/src/resolver.rs
+++ b/example/src/resolver.rs
@@ -1,0 +1,51 @@
+use cel::common::types::CelString;
+use cel::common::value::{BorrowedVal, Val};
+use cel::context::VariableResolver;
+use cel::parser::Parser;
+use cel::{Context, Value};
+use std::borrow::Cow;
+
+/// Whatever the variable resolved, we always return a `CelString` pointing to a single `str`
+struct MonotonicResolver<'a> {
+    some_ref: &'a str,
+    val: BorrowedVal<'a, CelString>,
+}
+
+impl<'a> VariableResolver for MonotonicResolver<'a> {
+    fn resolve(&self, _: &str) -> Option<Value> {
+        unreachable!("The interpreter should not call into this!")
+    }
+
+    fn resolve_val<'b>(&'b self, _variable: &str) -> Option<Cow<'b, dyn Val>> {
+        Some(Cow::Borrowed(self.val.inner()))
+    }
+}
+
+fn main() {
+    let parser = Parser::default();
+
+    // try replacing `==` with `!=`
+    let expr = "foo == 'bar' ? bar : 'bar'";
+
+    let ast = parser.parse(expr).unwrap();
+    let mut context = Context::default();
+    let bar = String::from("bar");
+    let resolver = MonotonicResolver {
+        some_ref: bar.as_str(),
+        val: BorrowedVal::from(bar.as_str()),
+    };
+    context.set_variable_resolver(&resolver);
+    let value = Value::resolve_val(&ast, &context).unwrap();
+
+    // This should always pass
+    assert_eq!(
+        value.as_ref().downcast_ref::<CelString>(),
+        Some(&CelString::from("bar"))
+    );
+
+    // But with when `foo != 'bar'`, we return a new CelString `"bar"`, the one borrowed from the AST
+    assert!(std::ptr::eq(
+        resolver.some_ref,
+        value.as_ref().downcast_ref::<CelString>().unwrap().inner()
+    ))
+}


### PR DESCRIPTION
PoC that tries to get rid of needing to copy data in the `Context` for variables.
Uses `CelString` as an example, if the pattern works, `CelBytes`, `CelList` and `CelMap` would need to be adapted in the same way. We could also have a utility `OpaqueRef<T>` wrapper of sorts.

- [x]  Create `CelString` with a `Borrowed` `&str`
- [x] Add new function to  `VariableResolver`: `resolve_val<'a>(&'a self, _variable: &str) -> Option<Cow<'a, dyn Val>>`
- [x] Have a test `MontonicVariableResolver<'a> { the_value: &'a str }`
- [x] Wire it all in a test that resolves all to the same `CelString` 

See [individual commits](https://github.com/cel-rust/cel-rust/pull/267/commits) for details on these individual bullet points. The last two are all in the `examples/resolver.rs`, single addition.