### PR TITLE
feat(context): make add_variable_as_val public

### DIFF
--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -90,7 +90,34 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub(crate) fn add_variable_as_val<S>(&mut self, name: S, value: Box<dyn Val>)
+    /// Binds a variable to a custom [`Val`] implementation directly, without
+    /// going through the [`Value`] enum.
+    ///
+    /// [`add_variable`](Self::add_variable) and
+    /// [`add_variable_from_value`](Self::add_variable_from_value) convert their
+    /// input into a [`Value`], whose compound variants ([`Value::Map`],
+    /// [`Value::List`], and `Value::Struct`) hold eagerly-materialized contents.
+    /// For a value that should resolve its contents *on access* instead — e.g.
+    /// a large or recursive backing object (a protobuf message, a database
+    /// row) where member access maps to
+    /// [`Indexer::get`](crate::common::traits::Indexer::get) and is computed
+    /// lazily — implement [`Val`] and the relevant operator traits (such as
+    /// [`Indexer`](crate::common::traits::Indexer),
+    /// [`Iterable`](crate::common::traits::Iterable),
+    /// [`Sizer`](crate::common::traits::Sizer)) for your type and bind it here.
+    /// The built-in implementations in
+    /// [`common::types`](crate::common::types) (e.g. `DefaultMap`, `Struct`)
+    /// are the reference for what to implement.
+    ///
+    /// ```ignore
+    /// // `my_value` implements `Val` + `Indexer`, resolving fields on access.
+    /// let mut ctx = Context::default();
+    /// ctx.add_variable_as_val("input", Box::new(my_value));
+    /// let program = Program::compile("input.field")?;
+    /// // `input.field` calls `Indexer::get` on `my_value` only when evaluated.
+    /// let result = program.execute(&ctx)?;
+    /// ```
+    pub fn add_variable_as_val<S>(&mut self, name: S, value: Box<dyn Val>)
     where
         S: Into<String>,
     {


### PR DESCRIPTION
## What

Makes `Context::add_variable_as_val(name, Box<dyn Val>)` public (it was
`pub(crate)`), with documentation and an example.

## Why

Binding a variable currently goes through the `Value` enum, whose compound
variants (`Map`, `List`, `Struct`) hold eagerly-materialized contents. There is
no public way to bind a custom `Val` implementation directly, so a value that
resolves its contents *on access* — e.g. a protobuf message or other
large/recursive backing object bound as a CEL variable, where member access
maps to `Indexer::get` and is computed lazily — cannot be used, even though the
`Val`/operator traits and the internal machinery already support it
(`add_variable_as_val` does exactly this internally today).

This is the smallest step that lets downstream users provide lazily-resolved
custom values, and it advances the "open type system" direction discussed in
#265. No behavior change.

## Notes

- `Val` and the operator traits (`Indexer`, `Iterable`, …) are already public
  under `cel::common`, so this one visibility change is sufficient.
- DCO signed off.
