### PR TITLE
Upgrade thiserror to 2

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = { version = "1.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 bytes = { version = "1", optional = true }
 
-thiserror = "1.0"
+thiserror = "2"
 pastey = "0.2.1"
 
 [dev-dependencies]

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1347,7 +1347,7 @@ impl Value {
                         let args = args?;
                         let qualified_func = match &target.expr {
                             Expr::Ident(prefix) => {
-                                let qualified_name = format!("{prefix}.{}", &call.func_name);
+                                let qualified_name = format!("{prefix}.{}", call.func_name);
                                 if let Some(op) = ctx.env().find_overload(&qualified_name, &args) {
                                     return op(args);
                                 }


### PR DESCRIPTION
## Summary
- upgrade cel from thiserror 1.x to thiserror 2
- keep the code changes minimal to a dependency update only

## Validation
- cargo test -p cel
- cargo test -p cel --all-features

Relates to #298.
