### PR TITLE
Add dyn() function for dynamic typing support

### DIFF
--- a/cel/src/common/types/dyn.rs
+++ b/cel/src/common/types/dyn.rs
@@ -1,0 +1,45 @@
+use crate::common::value::Val;
+use crate::ExecutionError;
+use std::borrow::Cow;
+
+/// `dyn` has no effect at runtime, it only signals to a type checker that its argument
+/// should be treated as dynamically typed. Returning the argument unchanged matches the
+/// `identity` binding cel-go declares for the same overload.
+fn to_dyn<'a>(mut args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    Ok(args.remove(0))
+}
+
+pub(crate) fn stdlib(env: &mut crate::Env) {
+    env.add_overload("dyn", "to_dyn", vec![super::DYN_TYPE], to_dyn)
+        .expect("Must be unique id");
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Context, Program};
+
+    fn eval(expr: &str) -> crate::objects::ResolveResult {
+        Program::compile(expr).unwrap().execute(&Context::default())
+    }
+
+    #[test]
+    fn returns_the_argument_unchanged() {
+        assert_eq!(eval("dyn(1)"), Ok(1.into()));
+        assert_eq!(eval("dyn('hello')"), Ok("hello".into()));
+        assert_eq!(eval("dyn([1, 2])"), Ok(vec![1, 2].into()));
+    }
+
+    #[test]
+    fn allows_cross_type_numeric_comparison() {
+        // The spec lists `dyn(3.0) == 3` as an equality example.
+        assert_eq!(eval("dyn(3.0) == 3"), Ok(true.into()));
+        assert_eq!(eval("dyn(1) == 1u"), Ok(true.into()));
+        assert_eq!(eval("dyn(1) < 2u"), Ok(true.into()));
+    }
+
+    #[test]
+    fn does_not_make_unrelated_types_equal() {
+        assert_eq!(eval("dyn(1) == 'a'"), Ok(false.into()));
+        assert_eq!(eval("dyn(1) == null"), Ok(false.into()));
+    }
+}

--- a/cel/src/common/types/dyn.rs
+++ b/cel/src/common/types/dyn.rs
@@ -5,6 +5,9 @@ use std::borrow::Cow;
 /// `dyn` has no effect at runtime, it only signals to a type checker that its argument
 /// should be treated as dynamically typed. Returning the argument unchanged matches the
 /// `identity` binding cel-go declares for the same overload.
+// TODO: this overload needs to be parameterized once the type system carries type
+// parameters, so that the declared signature is `dyn(A) -> dyn` and a container
+// argument yields `list(dyn)` or `map(dyn, dyn)` rather than a bare `dyn`. See #244.
 fn to_dyn<'a>(mut args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     Ok(args.remove(0))
 }

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod bytes;
 pub(crate) mod double;
 #[cfg(feature = "chrono")]
 pub(crate) mod duration;
+pub(crate) mod r#dyn;
 pub(crate) mod int;
 pub(crate) mod list;
 pub(crate) mod map;

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -71,6 +71,7 @@ impl Env {
         let mut env = Env::default();
         types::bytes::stdlib(&mut env);
         types::double::stdlib(&mut env);
+        types::r#dyn::stdlib(&mut env);
         types::int::stdlib(&mut env);
         types::list::stdlib(&mut env);
         types::map::stdlib(&mut env);


### PR DESCRIPTION
Refs #244. `dyn` isn't registered anywhere in `cel/src`, so any expression using it fails with `UndeclaredReference("dyn")`. This registers a single overload returning its argument unchanged, as discussed in the issue.

`DYN_TYPE` as the argument type already matches anything through the `Kind::Dyn` arm of `Type::is_assignable`, so one overload covers `dyn(A) -> dyn` for every A. It also shouldn't get in the way of the type parameter work: `OverloadDecl` has no `result_type` field yet, so declaring `dyn`'s result type is work #244 needs anyway.

Measured against the conformance suite in #291, since master has no harness: 151 tests flip from `should_panic` to passing, 888 -> 1039 actually conformant, no regressions. Mostly `comparisons::{eq,ne,lt,lte,gt,gte}_literal`, plus `lists::in` and `lists::index`.

Heterogeneous map keys (`{1: 1.0, 2u: 3u} == {1u: 1, 2: 3.0}`) are untouched. I'd like to pick those up in a follow-up once this lands.

---

AI assistance: I used Claude Code for the investigation, for drafting this change and its tests, and for running the conformance measurements. I reviewed and verified all of it and can explain any line.