### PR TITLE
feat: add per-invocation monotonic ExecutionBudget

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,32 @@ fn main() {
 }
 ```
 
+### Execution budgets
+
+Evaluation can take an optional per-invocation monotonic [`ExecutionBudget`](https://docs.rs/cel/latest/cel/struct.ExecutionBudget.html).
+The budget covers evaluation only (not compilation), is checked cooperatively by
+the interpreter, and does not mutate a compiled `Program`:
+
+```rust
+use cel::{Context, ExecutionBudget, Program};
+use std::time::Duration;
+
+let program = Program::compile("items.map(x, x + 1)").unwrap();
+let mut context = Context::default();
+context.add_variable_from_value("items", vec![1i64; 10_000]);
+
+let budget = ExecutionBudget::with_timeout(Duration::from_millis(5));
+match program.execute_with_budget(&context, budget) {
+    Ok(value) => println!("{value:?}"),
+    Err(cel::ExecutionError::DeadlineExceeded) => println!("timed out"),
+    Err(err) => panic!("{err}"),
+}
+```
+
+Host callbacks and other work that does not return to the interpreter cannot be
+preempted mid-call. This is complementary to CEL cost limiting (see
+[cel-rust#56](https://github.com/cel-rust/cel-rust/issues/56)).
+
 ### Examples
 
 Check out these other examples to learn how to use this library:

--- a/cel/src/budget.rs
+++ b/cel/src/budget.rs
@@ -1,0 +1,64 @@
+use crate::ExecutionError;
+use std::time::{Duration, Instant};
+
+/// Per-invocation monotonic execution budget for CEL evaluation.
+///
+/// A budget is cooperative: the interpreter checks the deadline before resolving
+/// AST nodes, around function dispatch, and on each comprehension iteration.
+/// Host callbacks and other long-running operations that do not return to the
+/// interpreter cannot be preempted mid-call.
+///
+/// Budgets are intended to be attached to a single `Program::execute` /
+/// [`Program::execute_with_budget`](crate::Program::execute_with_budget) call.
+/// They must not be stored as shared mutable state on a compiled
+/// [`Program`](crate::Program).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ExecutionBudget {
+    deadline: Option<Instant>,
+}
+
+impl ExecutionBudget {
+    /// No deadline; evaluation runs until it completes or fails for another reason.
+    pub const fn unlimited() -> Self {
+        Self { deadline: None }
+    }
+
+    /// Expire at an absolute monotonic instant.
+    pub fn with_deadline(deadline: Instant) -> Self {
+        Self {
+            deadline: Some(deadline),
+        }
+    }
+
+    /// Expire after `timeout` from now, using a monotonic clock.
+    ///
+    /// A zero duration creates an already-expired (or immediately-expiring)
+    /// budget, which is useful for deterministic tests.
+    pub fn with_timeout(timeout: Duration) -> Self {
+        Self {
+            deadline: Some(Instant::now() + timeout),
+        }
+    }
+
+    /// Returns `true` when no deadline is configured.
+    pub fn is_unlimited(&self) -> bool {
+        self.deadline.is_none()
+    }
+
+    /// Returns the configured monotonic deadline, if any.
+    pub fn deadline(&self) -> Option<Instant> {
+        self.deadline
+    }
+
+    /// Returns [`ExecutionError::DeadlineExceeded`] when the deadline has been
+    /// reached or passed.
+    #[inline]
+    pub fn check(&self) -> Result<(), ExecutionError> {
+        if let Some(deadline) = self.deadline {
+            if Instant::now() >= deadline {
+                return Err(ExecutionError::DeadlineExceeded);
+            }
+        }
+        Ok(())
+    }
+}

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -2,7 +2,7 @@ use crate::common::value::Val;
 use crate::magic::{Function, FunctionRegistry, IntoFunction};
 use crate::objects::{TryIntoValue, Value};
 use crate::parser::Expression;
-use crate::{Env, ExecutionError};
+use crate::{Env, ExecutionBudget, ExecutionError};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -38,11 +38,13 @@ pub enum Context<'a> {
         variables: BTreeMap<String, Box<dyn Val>>,
         resolver: Option<&'a dyn VariableResolver>,
         env: Arc<Env>,
+        budget: ExecutionBudget,
     },
     Child {
         parent: &'a Context<'a>,
         variables: BTreeMap<String, Box<dyn Val>>,
         resolver: Option<&'a dyn VariableResolver>,
+        budget: ExecutionBudget,
     },
 }
 
@@ -152,6 +154,7 @@ impl<'a> Context<'a> {
                 variables,
                 parent,
                 resolver,
+                ..
             } => resolver
                 .and_then(|r| {
                     r.resolve(name)
@@ -212,11 +215,51 @@ impl<'a> Context<'a> {
         Value::resolve_all(exprs, self)
     }
 
+    /// Returns the per-invocation execution budget attached to this context.
+    pub fn execution_budget(&self) -> ExecutionBudget {
+        match self {
+            Context::Root { budget, .. } | Context::Child { budget, .. } => *budget,
+        }
+    }
+
+    /// Sets the per-invocation execution budget on this context.
+    ///
+    /// Prefer [`Program::execute_with_budget`](crate::Program::execute_with_budget)
+    /// when you want to apply a budget without mutating a shared context.
+    pub fn set_execution_budget(&mut self, budget: ExecutionBudget) {
+        match self {
+            Context::Root { budget: slot, .. } | Context::Child { budget: slot, .. } => {
+                *slot = budget;
+            }
+        }
+    }
+
+    /// Returns a child context that uses `budget` for this invocation.
+    ///
+    /// The original context is not mutated. Variables, functions, and the
+    /// environment are resolved through the parent chain.
+    pub fn with_execution_budget(&'a self, budget: ExecutionBudget) -> Context<'a> {
+        Context::Child {
+            parent: self,
+            variables: Default::default(),
+            resolver: None,
+            budget,
+        }
+    }
+
+    /// Checks the attached execution budget and returns
+    /// [`ExecutionError::DeadlineExceeded`] when it has expired.
+    #[inline]
+    pub fn check_execution_budget(&self) -> Result<(), ExecutionError> {
+        self.execution_budget().check()
+    }
+
     pub fn new_inner_scope(&self) -> Context<'_> {
         Context::Child {
             parent: self,
             variables: Default::default(),
             resolver: None,
+            budget: self.execution_budget(),
         }
     }
 
@@ -237,6 +280,7 @@ impl<'a> Context<'a> {
             variables: Default::default(),
             functions: Default::default(),
             resolver: None,
+            budget: ExecutionBudget::unlimited(),
         }
     }
 
@@ -246,6 +290,7 @@ impl<'a> Context<'a> {
             variables: Default::default(),
             functions: Default::default(),
             resolver: None,
+            budget: ExecutionBudget::unlimited(),
         }
     }
 }
@@ -257,6 +302,7 @@ impl Default for Context<'_> {
             variables: Default::default(),
             functions: Default::default(),
             resolver: None,
+            budget: ExecutionBudget::unlimited(),
         }
     }
 }

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -19,11 +19,13 @@ use thiserror::Error;
 
 mod macros;
 
+mod budget;
 pub mod common;
 pub mod context;
 mod env;
 pub mod parser;
 
+pub use budget::ExecutionBudget;
 pub use common::ast::IdedExpr;
 use common::ast::SelectExpr;
 pub use context::Context;
@@ -129,6 +131,10 @@ pub enum ExecutionError {
     Overflow(&'static str, Value, Value),
     #[error("Index out of bounds: {0:?}")]
     IndexOutOfBounds(Value),
+    /// Indicates that the per-invocation monotonic execution budget expired
+    /// before evaluation completed.
+    #[error("Execution deadline exceeded")]
+    DeadlineExceeded,
     #[error("InternalError: {0:?}")]
     InternalError(String),
 }
@@ -171,6 +177,10 @@ impl ExecutionError {
     pub fn missing_argument_or_target() -> Self {
         ExecutionError::MissingArgumentOrTarget
     }
+
+    pub fn deadline_exceeded() -> Self {
+        ExecutionError::DeadlineExceeded
+    }
 }
 
 #[derive(Debug)]
@@ -188,6 +198,20 @@ impl Program {
 
     pub fn execute(&self, context: &Context) -> ResolveResult {
         Value::resolve(&self.expression, context)
+    }
+
+    /// Execute this program with a per-invocation [`ExecutionBudget`].
+    ///
+    /// The budget is applied through a temporary child scope and does not
+    /// mutate `context` or this compiled [`Program`]. Concurrent executions of
+    /// the same program may use independent budgets.
+    pub fn execute_with_budget(
+        &self,
+        context: &Context<'_>,
+        budget: ExecutionBudget,
+    ) -> ResolveResult {
+        let scoped = context.with_execution_budget(budget);
+        Value::resolve(&self.expression, &scoped)
     }
 
     /// Returns the variables and functions referenced by the CEL program
@@ -315,5 +339,126 @@ mod tests {
             let res = test_script(script, Some(ctx));
             assert_eq!(res, error.into(), "{name}");
         }
+    }
+
+    #[test]
+    fn execution_budget_unlimited_preserves_behavior() {
+        let program = Program::compile("[1, 2, 3].map(x, x * 2)").unwrap();
+        let ctx = Context::default();
+        assert_eq!(
+            program.execute(&ctx).unwrap(),
+            Value::List(vec![2i64.into(), 4i64.into(), 6i64.into()].into())
+        );
+        assert_eq!(
+            program
+                .execute_with_budget(&ctx, crate::ExecutionBudget::unlimited())
+                .unwrap(),
+            Value::List(vec![2i64.into(), 4i64.into(), 6i64.into()].into())
+        );
+    }
+
+    #[test]
+    fn execution_budget_zero_is_already_expired() {
+        let program = Program::compile("1 + 1").unwrap();
+        let ctx = Context::default();
+        let err = program
+            .execute_with_budget(
+                &ctx,
+                crate::ExecutionBudget::with_timeout(std::time::Duration::ZERO),
+            )
+            .unwrap_err();
+        assert_eq!(err, ExecutionError::DeadlineExceeded);
+    }
+
+    #[test]
+    fn execution_budget_interrupts_comprehension() {
+        let program = Program::compile("items.map(x, x + 1)").unwrap();
+        let mut ctx = Context::default();
+        ctx.add_variable_from_value("items", vec![1i64; 100_000]);
+
+        let started = std::time::Instant::now();
+        let err = program
+            .execute_with_budget(
+                &ctx,
+                crate::ExecutionBudget::with_timeout(std::time::Duration::from_millis(1)),
+            )
+            .unwrap_err();
+        let elapsed = started.elapsed();
+
+        assert_eq!(err, ExecutionError::DeadlineExceeded);
+        assert!(
+            elapsed < std::time::Duration::from_secs(1),
+            "expensive comprehension should return promptly, took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn execution_budget_is_per_invocation() {
+        let program = Program::compile("items.map(x, x + 1)").unwrap();
+        let mut ctx = Context::default();
+        ctx.add_variable_from_value("items", vec![1i64; 10_000]);
+
+        let err = program
+            .execute_with_budget(
+                &ctx,
+                crate::ExecutionBudget::with_timeout(std::time::Duration::ZERO),
+            )
+            .unwrap_err();
+        assert_eq!(err, ExecutionError::DeadlineExceeded);
+
+        // A later unlimited execution must still succeed; timeouts do not poison the program.
+        let value = program.execute(&ctx).unwrap();
+        assert!(matches!(value, Value::List(_)));
+    }
+
+    #[test]
+    fn execution_budget_does_not_mutate_shared_context() {
+        let program = Program::compile("1 + 1").unwrap();
+        let ctx = Context::default();
+        assert!(ctx.execution_budget().is_unlimited());
+
+        let _ = program
+            .execute_with_budget(
+                &ctx,
+                crate::ExecutionBudget::with_timeout(std::time::Duration::ZERO),
+            )
+            .unwrap_err();
+
+        assert!(ctx.execution_budget().is_unlimited());
+        assert_eq!(program.execute(&ctx).unwrap(), Value::Int(2));
+    }
+
+    #[test]
+    fn execution_budget_concurrent_timeout_and_success() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let program = Arc::new(Program::compile("items.map(x, x + 1)").unwrap());
+
+        let timeout_program = Arc::clone(&program);
+        let timeout_thread = thread::spawn(move || {
+            let mut ctx = Context::default();
+            ctx.add_variable_from_value("items", vec![1i64; 10_000]);
+            timeout_program.execute_with_budget(
+                &ctx,
+                crate::ExecutionBudget::with_timeout(std::time::Duration::ZERO),
+            )
+        });
+
+        let success_program = Arc::clone(&program);
+        let success_thread = thread::spawn(move || {
+            let mut ctx = Context::default();
+            ctx.add_variable_from_value("items", vec![1i64; 32]);
+            success_program.execute(&ctx)
+        });
+
+        assert_eq!(
+            timeout_thread.join().unwrap().unwrap_err(),
+            ExecutionError::DeadlineExceeded
+        );
+        assert!(matches!(
+            success_thread.join().unwrap().unwrap(),
+            Value::List(_)
+        ));
     }
 }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1007,6 +1007,7 @@ impl Value {
         expr: &'a Expression,
         ctx: &'a Context<'a>,
     ) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+        ctx.check_execution_budget()?;
         match &expr.expr {
             Expr::Literal(literal) => Ok(literal.to_val()),
             Expr::Call(call) => {
@@ -1328,12 +1329,14 @@ impl Value {
                             .map(|a| Value::resolve_val(a, ctx))
                             .collect();
                         let args = args?;
+                        ctx.check_execution_budget()?;
                         if let Some(op) = ctx.env().find_overload(&call.func_name, &args) {
                             return op(args);
                         }
                         let func = ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
                             ExecutionError::UndeclaredReference(call.func_name.clone().into())
                         })?;
+                        ctx.check_execution_budget()?;
                         let mut ctx = FunctionContext::new(&call.func_name, None, ctx, args);
                         let v = (func)(&mut ctx)?;
                         Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
@@ -1345,6 +1348,7 @@ impl Value {
                             .map(|a| Value::resolve_val(a, ctx))
                             .collect();
                         let args = args?;
+                        ctx.check_execution_budget()?;
                         let qualified_func = match &target.expr {
                             Expr::Ident(prefix) => {
                                 let qualified_name = format!("{prefix}.{}", call.func_name);
@@ -1360,6 +1364,7 @@ impl Value {
                                 let target = Value::resolve_val(target, ctx)?;
                                 let mut args = args;
                                 args.insert(0, target);
+                                ctx.check_execution_budget()?;
                                 if let Some(op) =
                                     ctx.env().find_member_overload(&call.func_name, &args)
                                 {
@@ -1376,6 +1381,7 @@ impl Value {
                             }
                             Some(func) => (None, func, args),
                         };
+                        ctx.check_execution_budget()?;
                         let mut ctx = FunctionContext::new(&call.func_name, target, ctx, args);
                         // todo fix this to _not_ use `Value`
                         let v = (func)(&mut ctx)?;
@@ -1497,6 +1503,7 @@ impl Value {
                     .ok_or(ExecutionError::NoSuchOverload)?
                     .iter();
                 while let Some(item) = items.next() {
+                    ctx.check_execution_budget()?;
                     if !try_bool(Value::resolve_val(&comprehension.loop_cond, &ctx))? {
                         break;
                     }


### PR DESCRIPTION
## Summary

Adds an optional per-invocation monotonic execution budget so callers can interrupt expensive CEL evaluation without mutating a compiled `Program`.

This is complementary to the expression-cost limiting discussed in #56: a time/deadline budget rather than a CEL cost model. It uses cooperative checks in the interpreter (`std::time::Instant`), not wall-clock time or forced preemption.

## API

```rust
use cel::{Context, ExecutionBudget, Program};
use std::time::Duration;

let program = Program::compile("items.map(x, x + 1)")?;
let mut ctx = Context::default();
ctx.add_variable_from_value("items", vec![1i64; 10_000]);

program.execute_with_budget(&ctx, ExecutionBudget::with_timeout(Duration::from_millis(5))?;
```

- `ExecutionBudget::unlimited()` / `with_timeout` / `with_deadline`
- `Program::execute_with_budget` applies the budget via a temporary child scope (does not mutate the shared context)
- `ExecutionError::DeadlineExceeded` on expiry
- Zero-duration budgets are already expired (useful for deterministic tests)

## Checks

Budget is checked:

- before resolving each AST/expression node
- around function / overload dispatch
- on every comprehension iteration (`map` / `filter` / `all` / `exists`, etc.)

## Non-goals / limitations

- Host callbacks and other work that does not return to the interpreter cannot be preempted mid-call
- This is not a CEL cost estimator; #56 remains relevant for cost-model limiting

## Test plan

- [x] Unlimited execution unchanged
- [x] Zero budget raises `DeadlineExceeded`
- [x] Large comprehension interrupted promptly
- [x] Concurrent timeout + success on shared program
- [x] Later unlimited execution not poisoned
- [x] `cargo test --workspace`, `cargo fmt`, `cargo clippy -D warnings`

## AI assistance

This PR was written with assistance from a Cursor agent for implementation and tests; the changes were human-reviewed.


Made with [Cursor](https://cursor.com)