### PR TITLE
Conformance parser

### DIFF
--- a/cel/src/parser/parser.rs
+++ b/cel/src/parser/parser.rs
@@ -144,15 +144,33 @@ impl Parser {
 
     /// Enables backtick-escaped field identifiers (``` `foo.bar` ```).
     ///
-    /// Only `false` (the default) is implemented today — with the flag off,
-    /// the parser rejects any `` `…` ``-quoted identifier with an
-    /// `"unsupported syntax: '`'"` parse error, matching cel-go's
-    /// `EnableIdentEscapeSyntax(false)` behavior (`parser/parser.go:161`).
-    /// Turning the flag on is not yet wired; it will still reject the
-    /// syntax until the unescape support lands.
+    /// With the flag off (the default) the parser rejects any `` `…` ``
+    /// -quoted identifier with an `"unsupported syntax: '`'"` parse error.
+    /// With the flag on the surrounding backticks are stripped and the
+    /// contents are used verbatim as the field name — matching cel-go's
+    /// `EnableIdentEscapeSyntax` (`parser/parser.go:161`).
     pub fn enable_ident_escape_syntax(mut self, enable: bool) -> Self {
         self.enable_ident_escape_syntax = enable;
         self
+    }
+
+    /// Returns the field name for an `escapeIdent` context, mirroring
+    /// cel-go's `normalizeIdent` (`parser/parser.go:161`). Returns an error
+    /// message string if the escape syntax is used without opting in.
+    fn normalize_ident(&self, ctx: &EscapeIdentContextAll<'_>) -> Result<String, &'static str> {
+        match ctx {
+            EscapeIdentContextAll::SimpleIdentifierContext(ident) => Ok(ident.get_text()),
+            EscapeIdentContextAll::EscapedIdentifierContext(ident) => {
+                if !self.enable_ident_escape_syntax {
+                    return Err("unsupported syntax: '`'");
+                }
+                let raw = ident.get_text();
+                // Grammar guarantees a leading and trailing backtick plus at
+                // least one interior char, so this slice is always safe.
+                Ok(raw[1..raw.len() - 1].to_string())
+            }
+            EscapeIdentContextAll::Error(_) => Err("unsupported ident kind"),
+        }
     }
 
     fn new_logic_manager(&self, func: &str, term: IdedExpr) -> LogicManager {
@@ -298,19 +316,13 @@ impl Parser {
                     continue;
                 }
                 Some(ident) => {
-                    if matches!(
-                        ident.as_ref(),
-                        EscapeIdentContextAll::EscapedIdentifierContext(_)
-                    ) && !self.enable_ident_escape_syntax
-                    {
-                        self.report_error::<ParseError, _>(
-                            field.start().deref(),
-                            None,
-                            "unsupported syntax: '`'",
-                        );
-                        continue;
-                    }
-                    let field_name = ident.get_text().to_string();
+                    let field_name = match self.normalize_ident(ident.as_ref()) {
+                        Ok(name) => name,
+                        Err(msg) => {
+                            self.report_error::<ParseError, _>(field.start().deref(), None, msg);
+                            continue;
+                        }
+                    };
                     let value = self.visit(ctx.values[i].as_ref());
                     let is_optional = match (&field.opt, self.enable_optional_syntax) {
                         (Some(opt), false) => {
@@ -900,18 +912,12 @@ impl gen::CELVisitorCompat<'_> for Parser {
     fn visit_Select(&mut self, ctx: &SelectContext<'_>) -> Self::Return {
         if let (Some(member), Some(id), Some(op)) = (&ctx.member(), &ctx.id, &ctx.op) {
             let operand = self.visit(member.as_ref());
-            if matches!(
-                id.as_ref(),
-                EscapeIdentContextAll::EscapedIdentifierContext(_)
-            ) && !self.enable_ident_escape_syntax
-            {
-                return self.report_error::<ParseError, _>(
-                    op.as_ref(),
-                    None,
-                    "unsupported syntax: '`'",
-                );
-            }
-            let field = id.get_text();
+            let field = match self.normalize_ident(id.as_ref()) {
+                Ok(f) => f,
+                Err(msg) => {
+                    return self.report_error::<ParseError, _>(op.as_ref(), None, msg);
+                }
+            };
             if let Some(_opt) = &ctx.opt {
                 return if self.enable_optional_syntax {
                     let field_literal = self.helper.next_expr(
@@ -1542,6 +1548,24 @@ mod tests {
             format!("{err}").contains("reserved identifier"),
             "expected reserved identifier error, got: {err}"
         );
+    }
+
+    #[test]
+    fn backtick_field_selector_strips_backticks_when_enabled() {
+        // With the flag on the parser should accept the source and lower it
+        // to a plain `Select` whose field is the unescaped identifier.
+        let expr = Parser::new()
+            .enable_ident_escape_syntax(true)
+            .parse("{'a/b': 1}.`a/b`")
+            .expect("should parse with ident-escape enabled");
+        // The outermost node is the Select — walk in and find its field.
+        fn field_of(expr: &crate::common::ast::Expr) -> Option<&str> {
+            match expr {
+                crate::common::ast::Expr::Select(sel) => Some(&sel.field),
+                _ => None,
+            }
+        }
+        assert_eq!(field_of(&expr.expr), Some("a/b"));
     }
 
     #[test]

--- a/cel/src/parser/parser.rs
+++ b/cel/src/parser/parser.rs
@@ -1075,13 +1075,20 @@ impl gen::CELVisitorCompat<'_> for Parser {
     }
 
     fn visit_Int(&mut self, ctx: &IntContext<'_>) -> Self::Return {
-        let string = ctx.get_text();
         if let Some(token) = ctx.tok.as_ref() {
-            let val = match if let Some(string) = string.strip_prefix("0x") {
-                i64::from_str_radix(string, 16)
+            // Strip `0x` from the numeric token first, then re-attach the
+            // sign — otherwise `-0x…` would be handed to a base-10 parser.
+            let raw = token.get_text();
+            let (radix, digits) = match raw.strip_prefix("0x") {
+                Some(rest) => (16, rest),
+                None => (10, raw),
+            };
+            let signed = if ctx.sign.is_some() {
+                format!("-{digits}")
             } else {
-                string.parse::<i64>()
-            } {
+                digits.to_string()
+            };
+            let val = match i64::from_str_radix(&signed, radix) {
                 Ok(v) => v,
                 Err(e) => return self.report_error(token, Some(e), "invalid int literal"),
             };

--- a/cel/src/parser/parser.rs
+++ b/cel/src/parser/parser.rs
@@ -7,13 +7,14 @@ use crate::parser::gen::{
     BoolFalseContext, BoolTrueContext, BytesContext, CELListener, CELParserContextType,
     CalcContext, CalcContextAttrs, ConditionalAndContext, ConditionalOrContext,
     ConstantLiteralContext, ConstantLiteralContextAttrs, CreateListContext, CreateMessageContext,
-    CreateStructContext, DoubleContext, ExprContext, Field_initializer_listContext,
-    GlobalCallContext, IdentContext, IndexContext, IndexContextAttrs, IntContext,
-    ListInitContextAll, LogicalNotContext, LogicalNotContextAttrs, MapInitializerListContextAll,
-    MemberCallContext, MemberCallContextAttrs, MemberExprContext, MemberExprContextAttrs,
-    NegateContext, NegateContextAttrs, NestedContext, NullContext, OptFieldContextAttrs,
-    PrimaryExprContext, PrimaryExprContextAttrs, RelationContext, RelationContextAttrs,
-    SelectContext, SelectContextAttrs, StartContext, StartContextAttrs, StringContext, UintContext,
+    CreateStructContext, DoubleContext, EscapeIdentContextAll, ExprContext,
+    Field_initializer_listContext, GlobalCallContext, IdentContext, IndexContext,
+    IndexContextAttrs, IntContext, ListInitContextAll, LogicalNotContext, LogicalNotContextAttrs,
+    MapInitializerListContextAll, MemberCallContext, MemberCallContextAttrs, MemberExprContext,
+    MemberExprContextAttrs, NegateContext, NegateContextAttrs, NestedContext, NullContext,
+    OptFieldContextAttrs, PrimaryExprContext, PrimaryExprContextAttrs, RelationContext,
+    RelationContextAttrs, SelectContext, SelectContextAttrs, StartContext, StartContextAttrs,
+    StringContext, UintContext,
 };
 use crate::parser::{gen, macros, parse};
 use antlr4rust::common_token_stream::CommonTokenStream;
@@ -105,6 +106,7 @@ pub struct Parser {
     max_recursion_depth: u16,
     error_recovery_limit: u32,
     enable_optional_syntax: bool,
+    enable_ident_escape_syntax: bool,
 }
 
 impl Parser {
@@ -118,6 +120,7 @@ impl Parser {
             max_recursion_depth: 96,
             error_recovery_limit: 30,
             enable_optional_syntax: false,
+            enable_ident_escape_syntax: false,
         }
     }
 
@@ -136,6 +139,19 @@ impl Parser {
 
     pub fn enable_optional_syntax(mut self, enable: bool) -> Self {
         self.enable_optional_syntax = enable;
+        self
+    }
+
+    /// Enables backtick-escaped field identifiers (``` `foo.bar` ```).
+    ///
+    /// Only `false` (the default) is implemented today — with the flag off,
+    /// the parser rejects any `` `…` ``-quoted identifier with an
+    /// `"unsupported syntax: '`'"` parse error, matching cel-go's
+    /// `EnableIdentEscapeSyntax(false)` behavior (`parser/parser.go:161`).
+    /// Turning the flag on is not yet wired; it will still reject the
+    /// syntax until the unescape support lands.
+    pub fn enable_ident_escape_syntax(mut self, enable: bool) -> Self {
+        self.enable_ident_escape_syntax = enable;
         self
     }
 
@@ -282,6 +298,18 @@ impl Parser {
                     continue;
                 }
                 Some(ident) => {
+                    if matches!(
+                        ident.as_ref(),
+                        EscapeIdentContextAll::EscapedIdentifierContext(_)
+                    ) && !self.enable_ident_escape_syntax
+                    {
+                        self.report_error::<ParseError, _>(
+                            field.start().deref(),
+                            None,
+                            "unsupported syntax: '`'",
+                        );
+                        continue;
+                    }
                     let field_name = ident.get_text().to_string();
                     let value = self.visit(ctx.values[i].as_ref());
                     let is_optional = match (&field.opt, self.enable_optional_syntax) {
@@ -872,6 +900,17 @@ impl gen::CELVisitorCompat<'_> for Parser {
     fn visit_Select(&mut self, ctx: &SelectContext<'_>) -> Self::Return {
         if let (Some(member), Some(id), Some(op)) = (&ctx.member(), &ctx.id, &ctx.op) {
             let operand = self.visit(member.as_ref());
+            if matches!(
+                id.as_ref(),
+                EscapeIdentContextAll::EscapedIdentifierContext(_)
+            ) && !self.enable_ident_escape_syntax
+            {
+                return self.report_error::<ParseError, _>(
+                    op.as_ref(),
+                    None,
+                    "unsupported syntax: '`'",
+                );
+            }
             let field = id.get_text();
             if let Some(_opt) = &ctx.opt {
                 return if self.enable_optional_syntax {
@@ -1502,6 +1541,20 @@ mod tests {
         assert!(
             format!("{err}").contains("reserved identifier"),
             "expected reserved identifier error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn backtick_field_selector_is_rejected_by_default() {
+        // Per cel-spec (matching cel-go `parser/parser.go:161` with
+        // `EnableIdentEscapeSyntax(false)`), the parser must reject
+        // backtick-quoted field selectors unless the feature is opted in.
+        let err = Parser::new()
+            .parse("{'a/b': 1}.`a/b`")
+            .expect_err("backtick selector must be rejected");
+        assert!(
+            format!("{err}").contains("unsupported syntax: '`'"),
+            "expected `unsupported syntax` error, got: {err}"
         );
     }
 

--- a/conformance/src/bin/ignored.txt
+++ b/conformance/src/bin/ignored.txt
@@ -1,4 +1,3 @@
-basic::self_eval_nonzeroish::self_eval_int_hex_negative
 bindings_ext::bind::bind_nested
 bindings_ext::bind::boolean_literal
 bindings_ext::bind::macro_exists

--- a/conformance/src/bin/ignored.txt
+++ b/conformance/src/bin/ignored.txt
@@ -426,6 +426,7 @@ fields::quoted_map_fields::field_access_dot
 fields::quoted_map_fields::field_access_slash
 fields::quoted_map_fields::has_field_dash
 fields::quoted_map_fields::has_field_dot
+fields::quoted_map_fields::has_field_slash
 fields::r#in::mixed_numbers_and_keys_absent
 fields::r#in::mixed_numbers_and_keys_present
 integer_math::int64_math::int64_min_negate

--- a/conformance/src/bin/ignored.txt
+++ b/conformance/src/bin/ignored.txt
@@ -421,12 +421,6 @@ fields::qualified_identifier_resolution::map_field_select
 fields::qualified_identifier_resolution::map_value_repeat_key
 fields::qualified_identifier_resolution::qualified_ident
 fields::qualified_identifier_resolution::qualified_identifier_resolution_unchecked
-fields::quoted_map_fields::field_access_dash
-fields::quoted_map_fields::field_access_dot
-fields::quoted_map_fields::field_access_slash
-fields::quoted_map_fields::has_field_dash
-fields::quoted_map_fields::has_field_dot
-fields::quoted_map_fields::has_field_slash
 fields::r#in::mixed_numbers_and_keys_absent
 fields::r#in::mixed_numbers_and_keys_present
 integer_math::int64_math::int64_min_negate

--- a/conformance/src/runner.rs
+++ b/conformance/src/runner.rs
@@ -27,9 +27,12 @@ pub fn run_test(simple_test_textproto: &str) {
     );
 
     // Use the parser directly so we can enable optional syntax (`.?`,
-    // `[?…]`, `{?k: v}`), which `Program::compile` leaves off by default.
+    // `[?…]`, `{?k: v}`) and backtick-escaped identifiers (`` `foo.bar` ``),
+    // which `Program::compile` leaves off by default. Matches cel-go's own
+    // conformance runner (`conformance/conformance_test.go:87,95`).
     let program = Parser::default()
         .enable_optional_syntax(true)
+        .enable_ident_escape_syntax(true)
         .parse(&test.expr)
         .expect("Failed to compile CEL expression");
 

--- a/conformance/tests/gen/basic.rs
+++ b/conformance/tests/gen/basic.rs
@@ -337,7 +337,6 @@ mod self_eval_nonzeroish {
     }
 
     // Test: self_eval_int_hex_negative
-    #[should_panic]
     #[test]
     fn self_eval_int_hex_negative() {
         run_test(&dedent!(

--- a/conformance/tests/gen/fields.rs
+++ b/conformance/tests/gen/fields.rs
@@ -628,7 +628,6 @@ mod quoted_map_fields {
     use dedent::dedent;
 
     // Test: field_access_slash
-    #[should_panic]
     #[test]
     fn field_access_slash() {
         run_test(&dedent!(
@@ -640,7 +639,6 @@ mod quoted_map_fields {
     }
 
     // Test: field_access_dash
-    #[should_panic]
     #[test]
     fn field_access_dash() {
         run_test(&dedent!(
@@ -652,7 +650,6 @@ mod quoted_map_fields {
     }
 
     // Test: field_access_dot
-    #[should_panic]
     #[test]
     fn field_access_dot() {
         run_test(&dedent!(
@@ -664,7 +661,6 @@ mod quoted_map_fields {
     }
 
     // Test: has_field_slash
-    #[should_panic]
     #[test]
     fn has_field_slash() {
         run_test(&dedent!(
@@ -676,7 +672,6 @@ mod quoted_map_fields {
     }
 
     // Test: has_field_dash
-    #[should_panic]
     #[test]
     fn has_field_dash() {
         run_test(&dedent!(
@@ -688,7 +683,6 @@ mod quoted_map_fields {
     }
 
     // Test: has_field_dot
-    #[should_panic]
     #[test]
     fn has_field_dot() {
         run_test(&dedent!(

--- a/conformance/tests/gen/fields.rs
+++ b/conformance/tests/gen/fields.rs
@@ -664,6 +664,7 @@ mod quoted_map_fields {
     }
 
     // Test: has_field_slash
+    #[should_panic]
     #[test]
     fn has_field_slash() {
         run_test(&dedent!(


### PR DESCRIPTION
This brings parity between the Pratt parser & the antlr4 based one

Does 2.5 things:
 - Fixes negative hex literal parsing
 - Adds support for ident escape syntax (with backticks)
   - One conformance test used to pass, that shouldn't have had, slight mix up in the parser and then the interpreter. Fixed 