### PR TITLE
fix(types): reject out-of-range int() and uint() conversions

### DIFF
--- a/cel/src/common/types/int.rs
+++ b/cel/src/common/types/int.rs
@@ -231,12 +231,38 @@ fn int<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionErr
     let arg = args.remove(0).into_owned();
     let ret: Result<Box<Int>, Box<dyn Val>> = match arg.get_type().kind() {
         Kind::Int => arg.downcast::<Int>(),
-        Kind::UInt => arg
-            .downcast::<CelUInt>()
-            .map(|arg| Box::new(Int::from(*arg.inner() as i64))),
-        Kind::Double => arg
-            .downcast::<CelDouble>()
-            .map(|arg| Box::new(Int::from(*arg.inner() as i64))),
+        Kind::UInt => match arg.downcast::<CelUInt>() {
+            Err(arg) => Err(arg),
+            Ok(arg) => match i64::try_from(*arg.inner()) {
+                Ok(value) => Ok(Box::new(Int::from(value))),
+                Err(_) => {
+                    return Err(ExecutionError::FunctionError {
+                        function: "int".to_owned(),
+                        message: "integer overflow".to_owned(),
+                    });
+                }
+            },
+        },
+        Kind::Double => match arg.downcast::<CelDouble>() {
+            Err(arg) => Err(arg),
+            Ok(arg) => {
+                let value = *arg.inner();
+                // Double to int conversions are limited to (minInt, maxInt) non-inclusive.
+                // 'i64::MAX as f64' rounds up to 2^63, and the largest double below that
+                // is 2^63 - 2^10, so the check also keeps 'value as i64' from saturating.
+                // 'i64::MIN as f64' is exactly -(2^63), so the exclusive lower bound
+                // rejects a double that i64 could actually hold. NaN, -infinity and
+                // infinity will also be rejected.
+                if !(value > (i64::MIN as f64) && value < (i64::MAX as f64)) {
+                    return Err(ExecutionError::FunctionError {
+                        function: "int".to_owned(),
+                        message: "integer overflow".to_owned(),
+                    });
+                }
+
+                Ok(Box::new(Int::from(value as i64)))
+            }
+        },
         Kind::String => match arg.downcast::<CelString>() {
             Err(arg) => Err(arg),
             Ok(arg) => match arg.inner().parse::<i64>() {
@@ -277,6 +303,7 @@ mod tests {
     use crate::common::traits::Comparer;
     use crate::common::types::{CelDouble, CelInt, CelString, CelUInt};
     use crate::common::value::Val;
+    use crate::{Context, Program};
     use std::cmp::Ordering::{Equal, Greater, Less};
 
     #[test]
@@ -300,5 +327,92 @@ mod tests {
         assert!(!int.equals(&CelDouble::from(f64::NAN)));
         assert!(!neg.equals(&CelDouble::from(f64::NAN)));
         assert!(!int.equals(&CelString::from("42")));
+    }
+
+    #[test]
+    fn test_conversion_boundaries() {
+        let context = Context::default();
+
+        // int(double) -> int
+        // Accepted doubles are those in (-2^63, 2^63) exclusive. The upper bound
+        // is 2^63 rather than i64::MAX because f64 cannot hold i64::MAX.
+        // The largest double below 2^63 is:
+        // 2^63 - 2^10 == 9223372036854774784
+        let program = Program::compile("int(9223372036854774784.0)").unwrap();
+        let value = program.execute(&context).unwrap();
+        assert_eq!(value, 9223372036854774784i64.into());
+
+        // int(double) -> int
+        // The smallest double above -2^63 is:
+        // -(2^63) + 2^10 == -9223372036854774784
+        let program = Program::compile("int(-9223372036854774784.0)").unwrap();
+        let value = program.execute(&context).unwrap();
+        assert_eq!(value, (-9223372036854774784i64).into());
+
+        // int(uint) -> int
+        // i64::MAX == (2^63 - 1) is the largest uint that still fits in an int
+        let program = Program::compile("int(9223372036854775807u)").unwrap();
+        let value = program.execute(&context).unwrap();
+        assert_eq!(value, 9223372036854775807i64.into());
+    }
+
+    #[test]
+    fn test_conversion_errors() {
+        let context = Context::default();
+
+        // int(double) -> int
+        // -2^63 is exactly representable as f64 and equals i64::MIN, but the
+        // lower bound is exclusive, so it should not convert:
+        // -(2^63) == -9223372036854775808
+        let program = Program::compile("int(-9223372036854775808.0)").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "int(-9223372036854775808.0) should return error, got {result:?}"
+        );
+
+        // int(double) -> int
+        // i64::MAX == 2^63 - 1 == 9223372036854775807 cannot be held by f64,
+        // so this literal rounds up to 2^63, which is outside the accepted range.
+        let program = Program::compile("int(9223372036854775807.0)").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "int(9223372036854775807.0) should return error, got {result:?}"
+        );
+
+        // int(double) -> int
+        let program = Program::compile("int(double('NaN'))").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "int(double('NaN')) should return error, got {result:?}"
+        );
+
+        // int(double) -> int
+        let program = Program::compile("int(double('infinity'))").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "int(double('infinity')) should return error, got {result:?}"
+        );
+
+        // int(double) -> int
+        let program = Program::compile("int(double('-infinity'))").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "int(double('-infinity')) should return error, got {result:?}"
+        );
+
+        // int(uint) -> int
+        // One above the largest uint that fits in an int:
+        // (i64::MAX + 1) == 2^63 == 9223372036854775808
+        let program = Program::compile("int(9223372036854775808u)").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "int(9223372036854775808u) should return error, got {result:?}"
+        );
     }
 }

--- a/cel/src/common/types/int.rs
+++ b/cel/src/common/types/int.rs
@@ -281,8 +281,8 @@ fn int<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionErr
     match ret {
         Ok(ret) => Ok(Cow::<dyn Val>::Owned(ret)),
         Err(arg) => Err(ExecutionError::FunctionError {
-            function: "double".to_owned(),
-            message: format!("cannot convert {arg:?} to double"),
+            function: "int".to_owned(),
+            message: format!("cannot convert {arg:?} to int"),
         }),
     }
 }

--- a/cel/src/common/types/uint.rs
+++ b/cel/src/common/types/uint.rs
@@ -288,7 +288,7 @@ fn uint<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionEr
                 Ok(arg) => Ok(Box::new(UInt::from(arg))),
                 Err(e) => {
                     return Err(ExecutionError::FunctionError {
-                        function: "int".to_owned(),
+                        function: "uint".to_owned(),
                         message: format!("string parse error: {e}"),
                     })
                 }
@@ -300,8 +300,8 @@ fn uint<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionEr
     match ret {
         Ok(ret) => Ok(Cow::<dyn Val>::Owned(ret)),
         Err(arg) => Err(ExecutionError::FunctionError {
-            function: "double".to_owned(),
-            message: format!("cannot convert {arg:?} to double"),
+            function: "uint".to_owned(),
+            message: format!("cannot convert {arg:?} to uint"),
         }),
     }
 }

--- a/cel/src/common/types/uint.rs
+++ b/cel/src/common/types/uint.rs
@@ -252,12 +252,36 @@ fn uint<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionEr
     let arg = args.remove(0).into_owned();
     let ret: Result<Box<UInt>, Box<dyn Val>> = match arg.get_type().kind() {
         Kind::UInt => arg.downcast::<UInt>(),
-        Kind::Int => arg
-            .downcast::<CelInt>()
-            .map(|arg| Box::new(UInt::from(*arg.inner() as u64))),
-        Kind::Double => arg
-            .downcast::<CelDouble>()
-            .map(|arg| Box::new(UInt::from(*arg.inner() as u64))),
+        Kind::Int => match arg.downcast::<CelInt>() {
+            Err(arg) => Err(arg),
+            Ok(arg) => match u64::try_from(*arg.inner()) {
+                Ok(value) => Ok(Box::new(UInt::from(value))),
+                Err(_) => {
+                    return Err(ExecutionError::FunctionError {
+                        function: "uint".to_owned(),
+                        message: "unsigned integer overflow".to_owned(),
+                    });
+                }
+            },
+        },
+        Kind::Double => match arg.downcast::<CelDouble>() {
+            Err(arg) => Err(arg),
+            Ok(arg) => {
+                let value = *arg.inner();
+                // Double to uint conversions are limited to [0, maxUint).
+                // 'u64::MAX as f64' rounds up to 2^64 and the largest double below that
+                // is 2^64 - 2^11, so the check also keeps 'value as u64' from saturating.
+                // NaN, -infinity and infinity will also be rejected.
+                if !(value >= 0.0 && value < (u64::MAX as f64)) {
+                    return Err(ExecutionError::FunctionError {
+                        function: "uint".to_owned(),
+                        message: "unsigned integer overflow".to_owned(),
+                    });
+                }
+
+                Ok(Box::new(UInt::from(value as u64)))
+            }
+        },
         Kind::String => match arg.downcast::<CelString>() {
             Err(arg) => Err(arg),
             Ok(arg) => match arg.inner().parse::<u64>() {
@@ -295,9 +319,12 @@ pub(crate) fn stdlib(env: &mut crate::Env) {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::{
-        types::{CelDouble, CelInt, CelString, CelUInt},
-        value::Val,
+    use crate::{
+        common::{
+            types::{CelDouble, CelInt, CelString, CelUInt},
+            value::Val,
+        },
+        Context, Program,
     };
 
     #[test]
@@ -310,5 +337,82 @@ mod tests {
         assert!(!uint.equals(&CelDouble::from(42.2)));
         assert!(!uint.equals(&CelDouble::from(f64::NAN)));
         assert!(!uint.equals(&CelString::from("42")));
+    }
+
+    #[test]
+    fn test_conversion_boundaries() {
+        let context = Context::default();
+
+        // uint(double) -> uint
+        let program = Program::compile("uint(0.0)").unwrap();
+        let value = program.execute(&context).unwrap();
+        assert_eq!(value, 0u64.into());
+
+        // uint(double) -> uint
+        // For double upper boundary we cannot test u64::MAX (2^64 - 1) since f64
+        // cannot hold that integer value. The closest integer value below is:
+        // 2^64 - 2^11 == 18446744073709549568
+        let program = Program::compile("uint(18446744073709549568.0)").unwrap();
+        let value = program.execute(&context).unwrap();
+        assert_eq!(value, 18446744073709549568u64.into());
+
+        // uint(int) -> uint
+        let program = Program::compile("uint(0)").unwrap();
+        let value = program.execute(&context).unwrap();
+        assert_eq!(value, 0u64.into());
+
+        // uint(int) -> uint
+        // i64::MAX == 2^63 - 1 == 9223372036854775807
+        let program = Program::compile("uint(9223372036854775807)").unwrap();
+        let value = program.execute(&context).unwrap();
+        assert_eq!(value, 9223372036854775807u64.into());
+    }
+
+    #[test]
+    fn test_conversion_errors() {
+        let context = Context::default();
+
+        let program = Program::compile("uint(-1)").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "uint(-1) should return error, got {result:?}"
+        );
+
+        let program = Program::compile("uint(-1.0)").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "uint(-1.0) should return error, got {result:?}"
+        );
+
+        // (u64::MAX + 1) == 2^64 == 18446744073709551616
+        let program = Program::compile("uint(18446744073709551616.0)").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "uint(18446744073709551616.0) should return error, got {result:?}"
+        );
+
+        let program = Program::compile("uint(double('NaN'))").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "uint(double('NaN')) should return error, got {result:?}"
+        );
+
+        let program = Program::compile("uint(double('infinity'))").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "uint(double('infinity')) should return error, got {result:?}"
+        );
+
+        let program = Program::compile("uint(double('-infinity'))").unwrap();
+        let result = program.execute(&context);
+        assert!(
+            result.is_err(),
+            "uint(double('-infinity')) should return error, got {result:?}"
+        );
     }
 }

--- a/conformance/src/bin/ignored.txt
+++ b/conformance/src/bin/ignored.txt
@@ -126,15 +126,8 @@ conversions::bool::string_true_pascalcase
 conversions::bool::string_true_uppercase
 conversions::identity::bool
 conversions::identity::timestamp
-conversions::int::double_int_max_range
-conversions::int::double_int_min_range
-conversions::int::double_range
 conversions::int::timestamp
-conversions::int::uint_range
 conversions::string::bytes_invalid
-conversions::uint::double_range_beyond_uint
-conversions::uint::double_uint_max_range
-conversions::uint::int_neg
 dynamic::any::field_assign_proto2
 dynamic::any::field_assign_proto3
 dynamic::any::field_read_proto2

--- a/conformance/tests/gen/conversions.rs
+++ b/conformance/tests/gen/conversions.rs
@@ -346,7 +346,6 @@ mod int {
     }
 
     // Test: uint_range
-    #[should_panic]
     #[test]
     fn uint_range() {
         run_test(&dedent!(
@@ -439,7 +438,6 @@ mod int {
     }
 
     // Test: double_int_max_range
-    #[should_panic]
     #[test]
     fn double_int_max_range() {
         run_test(&dedent!(
@@ -454,7 +452,6 @@ mod int {
     }
 
     // Test: double_int_min_range
-    #[should_panic]
     #[test]
     fn double_int_min_range() {
         run_test(&dedent!(
@@ -469,7 +466,6 @@ mod int {
     }
 
     // Test: double_range
-    #[should_panic]
     #[test]
     fn double_range() {
         run_test(&dedent!(
@@ -962,7 +958,6 @@ mod uint {
     }
 
     // Test: int_neg
-    #[should_panic]
     #[test]
     fn int_neg() {
         run_test(&dedent!(
@@ -1033,7 +1028,6 @@ mod uint {
     }
 
     // Test: double_uint_max_range
-    #[should_panic]
     #[test]
     fn double_uint_max_range() {
         run_test(&dedent!(
@@ -1048,7 +1042,6 @@ mod uint {
     }
 
     // Test: double_range_beyond_uint
-    #[should_panic]
     #[test]
     fn double_range_beyond_uint() {
         run_test(&dedent!(


### PR DESCRIPTION
Currently, `int(double)`, `uint(double)`, `int(uint)`, and `uint(int)` can silently return incorrect values when the input is outside the target type's representable range:

- Conversions from `double` saturate, and `NaN` converts to `0`
- Conversions between `int` and `uint` wrap

This PR adds explicit range checks so that these conversions return an error instead.

Tests cover boundary values and out-of-range inputs that previously produced incorrect results.

This also fixes a few copy-paste errors in the function names included in conversion error messages. Those changes are in a separate commit; I can drop them if you would prefer to keep this PR strictly scoped.


AI assistance disclosure:

- Used Perplexity GPT-5.6 Terra to help troubleshoot the conversion issue and proofread this PR description.
- Used Claude Opus 5 to assist with applying the corresponding `uint.rs` fix to `int.rs`, review the changes, and suggest additional test cases for better test coverage.

I reviewed all generated suggestions before submitting this PR.
