### PR TITLE
perf(macros): `map` mutates `List` in place

### DIFF
--- a/cel/src/common/types/list.rs
+++ b/cel/src/common/types/list.rs
@@ -6,6 +6,7 @@ use crate::ExecutionError;
 use std::any::Any;
 use std::borrow::Cow;
 use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Default)]
 pub struct DefaultList(Vec<Box<dyn Val>>);
@@ -244,6 +245,114 @@ impl<'a> traits::Iterator<'a> for SliceIterator<'a> {
     }
 }
 
+/// A mutable list that shares its backing storage across clones.
+///
+/// `MutableList` is an internal helper used by the comprehension evaluator
+/// (see [`crate::objects::Value::resolve_val`]) to build up the accumulator
+/// of `map` / `filter` comprehensions in place, avoiding the quadratic
+/// clone-on-add cost that a normal [`DefaultList`] would incur when the
+/// comprehension expands to `@result = @result + [expr]` on every iteration.
+///
+/// Only the surface the comprehension actually invokes on the accumulator
+/// is implemented — `Val` + [`Adder`]. `DefaultList` stays a full-fledged
+/// value type (with `Container`/`Indexer`/`Iterable`/`Sizer`/`Zeroer`);
+/// `MutableList` never leaves this scope, so those trait impls would be
+/// dead code.
+///
+/// It is not exposed to user code and should never be produced by
+/// user-defined overloads or programs. When a comprehension completes, the
+/// evaluator converts the accumulator back to a [`DefaultList`] via
+/// [`MutableList::to_immutable`].
+#[derive(Debug, Default)]
+#[doc(hidden)]
+pub struct MutableList {
+    inner: Arc<Mutex<Vec<Box<dyn Val>>>>,
+}
+
+impl MutableList {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Vec::with_capacity(cap))),
+        }
+    }
+
+    /// Converts the mutable list into an immutable [`DefaultList`], reusing
+    /// the backing storage if this handle is the only one still alive.
+    pub fn to_immutable(self) -> DefaultList {
+        match Arc::try_unwrap(self.inner) {
+            Ok(mutex) => DefaultList(mutex.into_inner().expect("mutable list mutex poisoned")),
+            Err(shared) => {
+                let guard = shared.lock().expect("mutable list mutex poisoned");
+                let mut out = Vec::with_capacity(guard.len());
+                for v in guard.iter() {
+                    out.push(v.clone_as_boxed());
+                }
+                DefaultList(out)
+            }
+        }
+    }
+
+    fn share(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+
+    #[cfg(test)]
+    fn len_for_test(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("mutable list mutex poisoned")
+            .len()
+    }
+}
+
+// `MutableList` only implements the Val + trait surface the comprehension
+// evaluator actually invokes on the accumulator:
+//   * `get_type` / `clone_as_boxed` — mandatory on every `Val`, and
+//     `clone_as_boxed` fires on every loop iteration when the accumulator
+//     is re-stored in the child context (the `Arc` inside means it's a
+//     refcount bump, not a buffer copy).
+//   * `as_adder` — invoked by the ADD dispatch every time the loop step
+//     evaluates `@result + [expr]`.
+// The other trait accessors (`as_iterable`, `as_indexer`, `as_container`,
+// `as_sizer`, `as_zeroer`) never fire because the accumulator identifier
+// `@result` is not typeable in CEL source, so user expressions can never
+// call `size()`, iterate, index, or use `in` on it; and the accumulator
+// is always frozen to `DefaultList` before it leaves the comprehension
+// scope, so no user code ever sees a `MutableList` either. Same reasoning
+// leaves `equals` at the default `false` — no one compares mutable lists.
+impl Val for MutableList {
+    fn get_type(&self) -> &Type {
+        &types::LIST_TYPE
+    }
+
+    fn as_adder(&self) -> Option<&dyn Adder> {
+        Some(self)
+    }
+
+    fn clone_as_boxed(&self) -> Box<dyn Val> {
+        Box::new(self.share())
+    }
+}
+
+impl Adder for MutableList {
+    fn add<'a>(&'a self, rhs: &dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+        let iter = rhs
+            .as_iterable()
+            .ok_or(ExecutionError::NoSuchOverload)?
+            .iter();
+        {
+            let mut inner = self.inner.lock().expect("mutable list mutex poisoned");
+            let mut items = iter;
+            while let Some(other) = items.next() {
+                inner.push(other.clone_as_boxed());
+            }
+        }
+        Ok(Cow::Borrowed(self as &dyn Val))
+    }
+}
+
 pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload(
         "size",
@@ -350,5 +459,45 @@ pub mod tests {
         let list: &[Box<dyn Val>] = list.as_ref().try_into().unwrap();
         assert_eq!(list[0].downcast_ref::<CelString>().unwrap().inner(), "cel");
         assert_eq!(list[1].downcast_ref::<CelString>().unwrap().inner(), "rust");
+    }
+
+    use crate::common::traits::Adder;
+    use crate::common::types::list::MutableList;
+
+    fn box_val<V: Val>(v: V) -> Box<dyn Val> {
+        Box::new(v)
+    }
+
+    #[test]
+    fn mutable_list_add_extends_in_place_across_clones() {
+        let m = MutableList::with_capacity(4);
+        let clone_box = m.clone_as_boxed();
+        let clone = clone_box.downcast_ref::<MutableList>().unwrap();
+
+        m.add(&DefaultList::from(vec![box_val(CelInt::from(1i64))]))
+            .unwrap();
+        m.add(&DefaultList::from(vec![box_val(CelInt::from(2i64))]))
+            .unwrap();
+        clone
+            .add(&DefaultList::from(vec![box_val(CelInt::from(3i64))]))
+            .unwrap();
+
+        // Both handles observe the same growing buffer.
+        assert_eq!(m.len_for_test(), 3);
+        assert_eq!(clone.len_for_test(), 3);
+    }
+
+    #[test]
+    fn mutable_list_to_immutable_preserves_order() {
+        let m = MutableList::with_capacity(0);
+        for i in 0..5i64 {
+            let rhs = DefaultList::from(vec![box_val(CelInt::from(i))]);
+            m.add(&rhs).unwrap();
+        }
+        let imm = m.to_immutable();
+        assert_eq!(imm.inner().len(), 5);
+        for (i, v) in imm.inner().iter().enumerate() {
+            assert_eq!(*v.downcast_ref::<CelInt>().unwrap().inner(), i as i64);
+        }
     }
 }

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -31,6 +31,8 @@ pub use double::Double as CelDouble;
 pub use duration::Duration as CelDuration;
 pub use int::Int as CelInt;
 pub use list::DefaultList as CelList;
+#[doc(hidden)]
+pub use list::MutableList;
 pub use map::DefaultMap as CelMap;
 pub use map::Key as CelMapKey;
 pub use null::Null as CelNull;

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1,7 +1,7 @@
 use crate::common::ast::{operators, EntryExpr, Expr};
 use crate::common::types::bool::Bool;
 use crate::common::types::*;
-use crate::common::value::Val;
+use crate::common::value::{Downcast, Val};
 use crate::context::Context;
 use crate::ExecutionError::NoSuchOverload;
 use crate::{ExecutionError, Expression, FunctionContext};
@@ -1525,8 +1525,33 @@ impl Value {
             Expr::Comprehension(comprehension) => {
                 let accu_init = Value::resolve_val(&comprehension.accu_init, ctx)?;
                 let iter = Value::resolve_val(&comprehension.iter_range, ctx)?;
+
+                // Mirror cel-go's optimization (see `folder.ResolveName` in
+                // `cel-go/interpreter/interpretable.go`): when the
+                // accumulator starts out as an empty list, swap it for a
+                // preallocated `MutableList` so the loop step
+                // (`@result + [expr]`) can grow a single shared buffer in
+                // place instead of paying O(n) clone-and-extend on every
+                // iteration. The ADD dispatch itself stays generic — it
+                // just calls `Adder::add` on whatever the accumulator
+                // resolves to, and `MutableList::add` mutates the shared
+                // `Arc<Mutex<Vec<_>>>` in place then returns
+                // `Cow::Borrowed(self)` (the "return the receiver" trick
+                // cel-go's `mutableList.Add` uses to keep the same pointer
+                // identity across iterations).
+                let accu_boxed: Box<dyn Val> = match accu_init.downcast_ref::<CelList>() {
+                    Some(list) if list.inner().is_empty() => {
+                        let size_hint = iter
+                            .as_sizer()
+                            .map(|s| *s.size().inner() as usize)
+                            .unwrap_or(0);
+                        Box::new(MutableList::with_capacity(size_hint))
+                    }
+                    _ => accu_init.clone_as_boxed(),
+                };
+
                 let mut ctx = ctx.new_inner_scope();
-                ctx.add_variable_as_val(&comprehension.accu_var, accu_init.clone_as_boxed());
+                ctx.add_variable_as_val(&comprehension.accu_var, accu_boxed);
 
                 let mut items = iter
                     .as_iterable()
@@ -1540,9 +1565,15 @@ impl Value {
                     let accu = Value::resolve_val(&comprehension.loop_step, &ctx)?;
                     ctx.add_variable_as_val(&comprehension.accu_var, accu.clone_as_boxed());
                 }
-                Ok(Cow::<dyn Val>::Owned(
-                    Value::resolve_val(&comprehension.result, &ctx)?.into_owned(),
-                ))
+                // Freeze the mutable accumulator back into an immutable
+                // list before it leaves the accu scope (cel-go does the
+                // analogous conversion in `folder.evalResult`).
+                let result = Value::resolve_val(&comprehension.result, &ctx)?.into_owned();
+                let result: Box<dyn Val> = match result.downcast::<MutableList>() {
+                    Ok(mutable) => Box::new(mutable.to_immutable()),
+                    Err(result) => result,
+                };
+                Ok(Cow::<dyn Val>::Owned(result))
             }
             Expr::Struct(strct) => {
                 let name = strct.type_name.clone();


### PR DESCRIPTION
**What type of PR is this?**
Perf improvement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #247 

**Does this PR introduce a user-facing change?**:
None, `.map` macro is now `O(n)` and not quadratic anymore

--- 

<details>

```
Benchmarking map list/map_10: Collecting 100 samples in estimated 5.0013 s (2.9M iterationsmap list/map_10         time:   [1.7360 µs 1.7449 µs 1.7550 µs]
                        change: [-41.596% -40.990% -40.194%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
Benchmarking map list/map_100: Collecting 100 samples in estimated 5.0371 s (293k iterationmap list/map_100        time:   [17.009 µs 17.063 µs 17.125 µs]
                        change: [-91.638% -91.577% -91.507%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking map list/map_1000: Collecting 100 samples in estimated 5.0412 s (30k iterationmap list/map_1000       time:   [168.18 µs 168.78 µs 169.37 µs]
                        change: [-99.045% -99.042% -99.038%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking map list/map_10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
Benchmarking map list/map_10000: Collecting 100 samples in estimated 8.5073 s (5050 iteratimap list/map_10000      time:   [1.7701 ms 1.7938 ms 1.8161 ms]
                        change: [-99.894% -99.893% -99.892%] (p = 0.00 < 0.05)
                        Performance has improved.
```

</details>
